### PR TITLE
Do not automatically sync site settings with Memberful

### DIFF
--- a/memberful-wp.php
+++ b/memberful-wp.php
@@ -61,9 +61,13 @@ if ( in_array( 'sensei/woothemes-sensei.php', apply_filters( 'active_plugins', g
   require_once MEMBERFUL_DIR . '/src/contrib/woothemes-sensei.php';
 }
 
-register_activation_hook( __FILE__, 'memberful_wp_plugin_activate' );
-
 function memberful_wp_plugin_activate() {
 	add_option( 'memberful_wp_activation_redirect' , true );
 	memberful_clear_obsolete_cron_jobs();
 }
+register_activation_hook( __FILE__, 'memberful_wp_plugin_activate' );
+
+function memberful_wp_plugin_deactivate() {
+	memberful_clear_cron_jobs();
+}
+register_deactivation_hook( __FILE__, 'memberful_wp_plugin_deactivate' );

--- a/memberful-wp.php
+++ b/memberful-wp.php
@@ -65,4 +65,5 @@ register_activation_hook( __FILE__, 'memberful_wp_plugin_activate' );
 
 function memberful_wp_plugin_activate() {
 	add_option( 'memberful_wp_activation_redirect' , true );
+	memberful_clear_obsolete_cron_jobs();
 }

--- a/src/cron.php
+++ b/src/cron.php
@@ -38,6 +38,10 @@ function memberful_wp_cron_sync_entities() {
 	echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";
 }
 
+function memberful_clear_cron_jobs() {
+	wp_clear_scheduled_hook("memberful_wp_cron_sync");
+}
+
 // We don't need this function forever. But in the past we were not cleaning up
 // our cron jobs on plugin deactivation, so we want to be sure that this
 // obsolete cron job is deactivated. Feel free to remove this (also from

--- a/src/cron.php
+++ b/src/cron.php
@@ -37,3 +37,11 @@ function memberful_wp_cron_sync_entities() {
 
 	echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";
 }
+
+// We don't need this function forever. But in the past we were not cleaning up
+// our cron jobs on plugin deactivation, so we want to be sure that this
+// obsolete cron job is deactivated. Feel free to remove this (also from
+// memberful-wp.php) if you are working on memberful-wp 1.24 and later.
+function memberful_clear_obsolete_cron_jobs() {
+	wp_clear_scheduled_hook("memberful_wp_cron_sync_settings");
+}

--- a/src/cron.php
+++ b/src/cron.php
@@ -1,12 +1,12 @@
 <?php
 
 if ( ! wp_next_scheduled( 'memberful_wp_cron_sync' ) ) {
-	  wp_schedule_event( time(), 'twicedaily', 'memberful_wp_cron_sync' );
+	wp_schedule_event( time(), 'twicedaily', 'memberful_wp_cron_sync' );
 }
 
 if( get_option( 'memberful_api_key' , '') != '' ) {
-  add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_users' );
-  add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_entities' );
+	add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_users' );
+	add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_entities' );
 }
 
 function memberful_clear_cron_jobs() {

--- a/src/cron.php
+++ b/src/cron.php
@@ -9,6 +9,10 @@ if( get_option( 'memberful_api_key' , '') != '' ) {
   add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_entities' );
 }
 
+function memberful_clear_cron_jobs() {
+	wp_clear_scheduled_hook("memberful_wp_cron_sync");
+}
+
 function memberful_wp_cron_sync_users() {
 	set_time_limit( 0 );
 
@@ -36,10 +40,6 @@ function memberful_wp_cron_sync_entities() {
 	memberful_wp_sync_subscription_plans();
 
 	echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";
-}
-
-function memberful_clear_cron_jobs() {
-	wp_clear_scheduled_hook("memberful_wp_cron_sync");
 }
 
 // We don't need this function forever. But in the past we were not cleaning up

--- a/src/cron.php
+++ b/src/cron.php
@@ -4,14 +4,9 @@ if ( ! wp_next_scheduled( 'memberful_wp_cron_sync' ) ) {
 	  wp_schedule_event( time(), 'twicedaily', 'memberful_wp_cron_sync' );
 }
 
-if ( ! wp_next_scheduled( 'memberful_wp_cron_sync_settings' ) ) {
-	  wp_schedule_event( time(), 'twicedaily', 'memberful_wp_cron_sync_settings' );
-}
-
 if( get_option( 'memberful_api_key' , '') != '' ) {
   add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_users' );
   add_action( 'memberful_wp_cron_sync', 'memberful_wp_cron_sync_entities' );
-  add_action( 'memberful_wp_cron_sync_settings', 'memberful_wp_cron_sync_settings' );
 }
 
 function memberful_wp_cron_sync_users() {
@@ -41,27 +36,4 @@ function memberful_wp_cron_sync_entities() {
 	memberful_wp_sync_subscription_plans();
 
 	echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";
-}
-
-function memberful_wp_cron_sync_settings() {
-	set_time_limit( 0 );
-
-	echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_settings at=start\n</pre>";
-
-	$new_settings = array(
-		'oauth' => array(
-			'website' => home_url(),
-			'redirect_uri' => memberful_wp_oauth_callback_url(),
-		),
-		'webhook' => array(
-			'url' => memberful_wp_webhook_url(),
-		),
-	);
-
-	memberful_wp_put_data_to_api_as_json(
-		memberful_wp_update_plugin_settings_on_memberful_url(),
-		$new_settings
-	);
-
-	echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_settings at=finish\n</pre>";
 }

--- a/src/options.php
+++ b/src/options.php
@@ -1,10 +1,6 @@
 <?php
 require MEMBERFUL_DIR.'/src/user/map_stats.php';
 
-add_action( 'update_option_home',     'memberful_wp_prepare_to_sync_options_to_memberful' );
-add_action( 'update_option_blogname', 'memberful_wp_prepare_to_sync_options_to_memberful' );
-add_filter( 'wp_redirect',            'memberful_wp_intercept_redirect_after_updating_options' );
-
 function memberful_wp_all_options() {
 	return array(
 		'memberful_client_id' => NULL,
@@ -57,17 +53,6 @@ function memberful_wp_option_values() {
 	}
 
 	return $config;
-}
-
-function memberful_wp_prepare_to_sync_options_to_memberful($new_value) {
-	$GLOBALS['memberful_wp_options_changed'] = true;
-}
-
-function memberful_wp_intercept_redirect_after_updating_options($location) {
-	if ( ! empty( $GLOBALS['memberful_wp_options_changed'] ) )
-		memberful_wp_send_site_options_to_memberful();
-
-	return $location;
 }
 
 function memberful_wp_site_name() {

--- a/src/options.php
+++ b/src/options.php
@@ -69,4 +69,3 @@ function memberful_wp_send_site_options_to_memberful() {
 		$options
 	);
 }
-


### PR DESCRIPTION
This PR:

- fixes #168 
- removes automatic synchronization of site settings with Memberful
- makes sure that we cleanup Memberful WP cron jobs on plugin deactivation