### PR TITLE
Fix private RSS for logged out users

### DIFF
--- a/views/private_user_feed_content.php
+++ b/views/private_user_feed_content.php
@@ -7,7 +7,7 @@ remove_all_filters('the_excerpt');
 remove_all_filters('the_excerpt_rss');
 
 // For the content parse, we want to remove only the memberful part.
-remove_filter('the_content', 'memberful_wp_protect_content');
+remove_filter('the_content', 'memberful_wp_protect_content', -10);
 
 query_posts(array(
   'post_type'       => 'post',


### PR DESCRIPTION
`remove_action` should match function name and priority, otherwise it will not work as expected.

We want to display private feeds also when user is not logged in so they can be used with feed aggregators. This commit fixes it.