### PR TITLE
Fix plugin registration with empty registration key

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -51,6 +51,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 = 1.28.0 =
 
 * Add Memberful links to the menu builder.
+* Fix plugin registration with empty registration key.
 
 = 1.27.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -121,16 +121,18 @@ function memberful_wp_admin_enqueue_scripts() {
 function memberful_wp_register() {
   $vars = array();
 
-  if ( ! empty( $_POST['activation_code'] ) ) {
-    $activation = memberful_wp_activate( $_POST['activation_code'] );
+  if ( isset( $_POST['activation_code'] ) ) {
+    if ( ! empty( $_POST['activation_code'] ) ) {
+      $activation = memberful_wp_activate( $_POST['activation_code'] );
 
-    if ( $activation === TRUE ) {
-      update_option( 'memberful_embed_enabled', TRUE );
-      memberful_wp_sync_downloads();
-      memberful_wp_sync_subscription_plans();
-    }
-    else {
-      Memberful_Wp_Reporting::report( $activation, 'error' );
+      if ( $activation === TRUE ) {
+        update_option( 'memberful_embed_enabled', TRUE );
+        memberful_wp_sync_downloads();
+        memberful_wp_sync_subscription_plans();
+      }
+      else {
+        Memberful_Wp_Reporting::report( $activation, 'error' );
+      }
     }
 
     return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );


### PR DESCRIPTION
Previously, when an empty registration key was submitted, then we showed only our form, without any other WordPress elements and without any styling. It looked bad. Especially because this is one of the first things which our users can see. This commit fixes it.