### PR TITLE
Add support for past due subscriptions

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -50,6 +50,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 = Development =
 
+* Add support for past due subscriptions.
 * Add class to the profile widget. Allows for more CSS modifications.
 
 = 1.28.1 =

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -55,7 +55,13 @@ function memberful_wp_user_disallowed_post_ids( $user_id ) {
 }
 
 function memberful_wp_filter_active_subscriptions($subscription) {
-  return empty($subscription['expires_at']) || $subscription['expires_at'] > time();
+  /**
+   * We can check only the `active` attribute once all of our customers use
+   * Memberful WP >= 1.29.
+   */
+  return ( isset( $subscription['active'] ) && $subscription['active'] )
+    || empty($subscription['expires_at'])
+    || $subscription['expires_at'] > time();
 }
 
 /**
@@ -135,7 +141,13 @@ function memberful_wp_user_has_subscription_to_plans( $user_id, array $required_
     if ( isset( $plans_user_is_subscribed_to[ $plan ] ) ) {
       $subscription = $plans_user_is_subscribed_to[ $plan ];
 
-      if ( empty( $subscription['expires_at'] ) || $subscription['expires_at'] > time() )
+      /**
+       * We can check only the `active` attribute once all of our customers use
+       * Memberful WP >= 1.29.
+       */
+      if ( ( isset( $subscription['active'] ) && $subscription['active'] )
+        || empty( $subscription['expires_at'] )
+        || $subscription['expires_at'] > time() )
         return TRUE;
     }
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/subscriptions.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/subscriptions.php
@@ -18,10 +18,11 @@ class Memberful_Wp_User_Subscriptions extends Memberful_Wp_User_Entity {
 
   protected function format( $entity ) {
     return array(
-      'id'         => $entity->subscription->id,
+      'active'     => $entity->active,
+      'autorenew'  => $entity->renew_at_end_of_period,
       'expires'    => $entity->expires,
       'expires_at' => $entity->expires_at,
-      'autorenew'  => $entity->renew_at_end_of_period
+      'id'         => $entity->subscription->id
     );
   }
 }


### PR DESCRIPTION
We have implemented multi-day renewals recently. Basically it means that
a subscription can be active up to two days after the expiration date.
Therefore it is not enough to check the `expires_at` attribute to find
out if subscription is active or not. The best way how to check
subscription status is to trust Memberful and check only the `active`
attribute.

Unfortunately we can't rely only on the `active` attribute because we
weren't storing it before (and our API wasn't providing it). Therefore,
first we will check if the `active` attribute is set. If yes, then we
will use it. If not, then we fallback back to the `expires_at` attribute.