### PR TITLE
Add support for past due subscriptions

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -50,6 +50,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 = Development =
 
+* Add support for past due subscriptions.
 * Add class to the profile widget. Allows for more CSS modifications.
 
 = 1.28.1 =

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -30,9 +30,6 @@ function memberful_wp_user_disallowed_post_ids( $user_id ) {
   $user_products = memberful_wp_user_downloads( $user_id );
   $user_subs     = memberful_wp_user_plans_subscribed_to( $user_id );
 
-  if ( ! empty( $user_subs ) )
-    $user_subs     = array_filter( $user_subs, 'memberful_wp_filter_active_subscriptions' );
-
   // Work out the set of posts the user is and isn't allowed to access
   $user_product_acl      = memberful_wp_generate_user_specific_acl_from_global_acl( $user_products, $global_product_acl );
   $user_subscription_acl = memberful_wp_generate_user_specific_acl_from_global_acl( $user_subs, $global_subscription_acl );
@@ -52,10 +49,6 @@ function memberful_wp_user_disallowed_post_ids( $user_id ) {
   }
 
   return $ids[$user_id] = ( empty( $posts_user_is_not_allowed_to_access ) ) ? array() : array_combine( $posts_user_is_not_allowed_to_access, $posts_user_is_not_allowed_to_access );
-}
-
-function memberful_wp_filter_active_subscriptions($subscription) {
-  return empty($subscription['expires_at']) || $subscription['expires_at'] > time();
 }
 
 /**
@@ -133,10 +126,7 @@ function memberful_wp_user_has_subscription_to_plans( $user_id, array $required_
 
   foreach ( $required_plans as $plan ) {
     if ( isset( $plans_user_is_subscribed_to[ $plan ] ) ) {
-      $subscription = $plans_user_is_subscribed_to[ $plan ];
-
-      if ( empty( $subscription['expires_at'] ) || $subscription['expires_at'] > time() )
-        return TRUE;
+      return TRUE;
     }
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/subscriptions.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/subscriptions.php
@@ -18,10 +18,10 @@ class Memberful_Wp_User_Subscriptions extends Memberful_Wp_User_Entity {
 
   protected function format( $entity ) {
     return array(
-      'id'         => $entity->subscription->id,
+      'autorenew'  => $entity->renew_at_end_of_period,
       'expires'    => $entity->expires,
       'expires_at' => $entity->expires_at,
-      'autorenew'  => $entity->renew_at_end_of_period
+      'id'         => $entity->subscription->id
     );
   }
 }


### PR DESCRIPTION
We have implemented multi-day renewals recently. Basically it means that
a subscription can be active up to two days after the expiration date.
Therefore it doesn't make sense to check the `expires_at` attribute,
because all subscriptions in user meta are active. If they are not
active, then we do not receive and save them.

This change also means that we are going to trust Memberful that it
always updates WordPress when subscription status changes so we can
synchronize new user details and act upon it.