### PR TITLE
Remove debug error logging

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -48,6 +48,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= DEVELOPMENT =
+
+* Fix login failures in some WordPress environments.
+
 = 1.29.1 =
 
 * Improve error handling.

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -187,7 +187,6 @@ function memberful_wp_debug() {
   $config                = memberful_wp_option_values();
   $acl_for_all_posts     = _memberful_wp_debug_all_post_meta();
   $plugins               = get_plugins();
-  $error_log             = memberful_wp_error_log();
 
   if($total_users != $total_mapped_users) {
     $mapping_records = $mapping_stats->mapping_records();

--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -42,8 +42,6 @@ function memberful_wp_get_data_from_api( $url ) {
 
   $response = wp_remote_get( $url, $request );
 
-  memberful_wp_instrument_api_call( $url, $request, $response );
-
   return $response;
 }
 
@@ -62,8 +60,6 @@ function memberful_wp_post_data_to_api_as_json( $url, $data ) {
   );
 
   $response = wp_remote_post( $url, $request );
-
-  memberful_wp_instrument_api_call( $url, $request, $response );
 
   return $response;
 }
@@ -84,91 +80,5 @@ function memberful_wp_put_data_to_api_as_json( $url, $data ) {
 
   $response = wp_remote_post( $url, $request );
 
-  memberful_wp_instrument_api_call( $url, $request, $response );
-
   return $response;
 }
-
-function memberful_wp_instrument_api_call( $url, $request, $response ) {
-  $error_payload = NULL;
-
-  if ( is_wp_error( $response ) ) {
-    $error_payload = memberful_wp_extract_api_error_log_from_wp_error( $response );
-  } else {
-    $status_code = (int) wp_remote_retrieve_response_code( $response );
-
-    if ( $status_code < 200 || $status_code >= 400 ) {
-      $error_payload = memberful_wp_extract_api_error_log_from_response( $response );
-    }
-  }
-
-  if ( $error_payload !== NULL ) {
-    $error_payload['url']       = $url;
-    $error_payload['sslverify'] = $request['sslverify'];
-
-    memberful_wp_record_error( $error_payload );
-  }
-}
-
-function memberful_wp_extract_api_error_log_from_wp_error( $wp_error ) {
-  return array(
-    'status'   => 0,
-    'codes'    => $wp_error->get_error_codes(),
-    'messages' => $wp_error->get_error_messages(),
-  );
-}
-
-function memberful_wp_extract_api_error_log_from_response( $response ) {
-  $headers = isset( $response['headers'] ) ? $response['headers'] : array();
-
-  return array(
-    'status'       => (int) wp_remote_retrieve_response_code( $response ),
-    'request_id'   => isset( $headers['x-request-id'] ) ? $headers['x-request-id'] : 'unknown',
-    'cache_hit'    => isset( $headers['x-rack-cache'] ) ? $headers['x-rack-cache'] : 'unknown',
-    'runtime'      => isset( $headers['x-runtime'] )    ? $headers['x-runtime']    : 'unknown',
-    'content_type' => isset( $headers['content-type'])  ? $headers['content-type'] : 'unknown',
-  );
-}
-
-function memberful_wp_error_log() {
-  return get_option( 'memberful_error_log', array() );
-}
-
-function memberful_wp_record_wp_error( $wp_error ) {
-  return memberful_wp_record_error(array(
-    'codes'    => $wp_error->get_error_codes(),
-    'messages' => $wp_error->get_error_messages(),
-    'data'     => $wp_error->get_error_data()
-  ));
-}
-
-function memberful_wp_record_error( $new_payload ) {
-  if ( ! isset( $new_payload['caller'] ) ) {
-    $new_payload['caller'] = array_map('memberful_wp_strip_args_from_backtrace', array_slice(debug_backtrace(), 1, 10));
-  }
-
-  if ( ! isset( $new_payload['date'] ) ) {
-    $new_payload['date'] = gmdate('c');
-  }
-
-  return memberful_wp_store_error( $new_payload );
-}
-
-function memberful_wp_strip_args_from_backtrace( $line ) {
-  unset($line['args']);
-
-  return $line;
-}
-
-function memberful_wp_store_error( $new_payload ) {
-  // Try not to overload the WP options table with errors!
-  $error_log = array_slice( memberful_wp_error_log(), 0, 99, TRUE );
-
-  array_unshift( $error_log, $new_payload );
-
-  update_option( 'memberful_error_log', $error_log );
-
-  return true;
-}
-
-

--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -165,7 +165,6 @@ class Memberful_Authenticator {
     $response = memberful_wp_post_data_to_api_as_json( self::oauth_member_url('token'), $params );
 
     if ( is_wp_error($response) ) {
-      memberful_wp_record_wp_error( $response );
       return $this->_error( 'could_not_get_tokens', $response );
     }
 
@@ -178,8 +177,6 @@ class Memberful_Authenticator {
         'error' => 'Could not get access token from Memberful',
         'response' => $response
       );
-
-      memberful_wp_record_error( $payload );
 
       return $this->_error(
         $payload['code'],

--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -8,10 +8,6 @@ function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context =
   $account = memberful_api_member( $member_id );
 
   if ( is_wp_error( $account ) ) {
-    memberful_wp_record_error(array(
-      'error'  => $account->get_error_messages()
-    ));
-
     return $account;
   }
 
@@ -38,12 +34,6 @@ function memberful_wp_sync_member_account( $account, $mapping_context ) {
 
       Memberful_Wp_User_Role_Decision::ensure_user_role_is_correct( $user );
     }
-  } else {
-    memberful_wp_record_error(array(
-      'error' => $user->get_error_messages(),
-      'code'  => $user->get_error_code(),
-      'member_email' => $account->member->email
-    ));
   }
 
   return $user;

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -104,10 +104,6 @@ class Memberful_User_Map {
 
     if ( is_wp_error( $outcome_of_mapping ) ) {
       if ( $outcome_of_mapping->get_error_code() === "duplicate_user_for_member" && ! $wp_user_existed_before_request ) {
-        // We only record this error as others will be passed up and recorded
-        // by something else, whereas here we're working around the error.
-        memberful_wp_record_wp_error( $outcome_of_mapping );
-
         wp_delete_user( $wp_user->ID );
 
         $error_data = $outcome_of_mapping->get_error_data();


### PR DESCRIPTION
We had issues with this code in several sites. `update_option` call was
failing with the error message: `Serialization of 'Closure' is not allowed`.

In an ideal case I would just solve this error and keep error reporting
in place. But in reality I wasn't able to reproduce this error,
therefore I couldn't fix it. Also, debug logging was kind of useful, but
not so much, because usually I was able to get admin access to affected
sites and I was able to solve issues without the debug log.