### PR TITLE
Cleanup memberful_wp_cron_sync_users

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/cron.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/cron.php
@@ -17,7 +17,6 @@ function memberful_wp_cron_sync_users() {
   set_time_limit( 0 );
 
   $members_to_sync = Memberful_User_Mapping_Repository::fetch_ids_of_members_that_need_syncing();
-  $mapper = new Memberful_User_Map();
 
   echo "<pre>library=memberful_wp fn=memberful_wp_cron_sync_users at=start members=".count($members_to_sync)."\n</pre>";
 


### PR DESCRIPTION
It appears that $mapper is no longer used in memberful_wp_cron_sync_users().