### PR TITLE
Add back debug logging

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -48,6 +48,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= Development =
+
+* Make debugging of plugin issues easier.
+
 = 1.32.0 =
 
 * Improve user synchronization with Memberful.

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -189,6 +189,8 @@ function memberful_wp_debug() {
   $plugins               = get_plugins();
   $error_log             = memberful_wp_error_log();
 
+  unset( $config['memberful_error_log'] );
+
   if($total_users != $total_mapped_users) {
     $mapping_records = $mapping_stats->mapping_records();
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -187,6 +187,7 @@ function memberful_wp_debug() {
   $config                = memberful_wp_option_values();
   $acl_for_all_posts     = _memberful_wp_debug_all_post_meta();
   $plugins               = get_plugins();
+  $error_log             = memberful_wp_error_log();
 
   if($total_users != $total_mapped_users) {
     $mapping_records = $mapping_stats->mapping_records();

--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -142,22 +142,17 @@ function memberful_wp_record_wp_error( $wp_error ) {
   ));
 }
 
-function memberful_wp_record_error( $new_payload ) {
-  if ( ! isset( $new_payload['caller'] ) ) {
-    $new_payload['caller'] = array_map('memberful_wp_strip_args_from_backtrace', array_slice(debug_backtrace(), 1, 10));
-  }
+function memberful_wp_record_error( $payload ) {
+  $payload['backtrace'] = memberful_get_backtrace_as_string();
+  $payload['date'] = gmdate('c');
 
-  if ( ! isset( $new_payload['date'] ) ) {
-    $new_payload['date'] = gmdate('c');
-  }
-
-  return memberful_wp_store_error( $new_payload );
+  return memberful_wp_store_error( $payload );
 }
 
-function memberful_wp_strip_args_from_backtrace( $line ) {
-  unset($line['args']);
-
-  return $line;
+function memberful_get_backtrace_as_string() {
+  ob_start();
+  debug_print_backtrace();
+  return ob_get_clean();
 }
 
 function memberful_wp_store_error( $new_payload ) {
@@ -170,5 +165,3 @@ function memberful_wp_store_error( $new_payload ) {
 
   return true;
 }
-
-

--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -42,6 +42,8 @@ function memberful_wp_get_data_from_api( $url ) {
 
   $response = wp_remote_get( $url, $request );
 
+  memberful_wp_instrument_api_call( $url, $request, $response );
+
   return $response;
 }
 
@@ -60,6 +62,8 @@ function memberful_wp_post_data_to_api_as_json( $url, $data ) {
   );
 
   $response = wp_remote_post( $url, $request );
+
+  memberful_wp_instrument_api_call( $url, $request, $response );
 
   return $response;
 }
@@ -80,5 +84,91 @@ function memberful_wp_put_data_to_api_as_json( $url, $data ) {
 
   $response = wp_remote_post( $url, $request );
 
+  memberful_wp_instrument_api_call( $url, $request, $response );
+
   return $response;
 }
+
+function memberful_wp_instrument_api_call( $url, $request, $response ) {
+  $error_payload = NULL;
+
+  if ( is_wp_error( $response ) ) {
+    $error_payload = memberful_wp_extract_api_error_log_from_wp_error( $response );
+  } else {
+    $status_code = (int) wp_remote_retrieve_response_code( $response );
+
+    if ( $status_code < 200 || $status_code >= 400 ) {
+      $error_payload = memberful_wp_extract_api_error_log_from_response( $response );
+    }
+  }
+
+  if ( $error_payload !== NULL ) {
+    $error_payload['url']       = $url;
+    $error_payload['sslverify'] = $request['sslverify'];
+
+    memberful_wp_record_error( $error_payload );
+  }
+}
+
+function memberful_wp_extract_api_error_log_from_wp_error( $wp_error ) {
+  return array(
+    'status'   => 0,
+    'codes'    => $wp_error->get_error_codes(),
+    'messages' => $wp_error->get_error_messages(),
+  );
+}
+
+function memberful_wp_extract_api_error_log_from_response( $response ) {
+  $headers = isset( $response['headers'] ) ? $response['headers'] : array();
+
+  return array(
+    'status'       => (int) wp_remote_retrieve_response_code( $response ),
+    'request_id'   => isset( $headers['x-request-id'] ) ? $headers['x-request-id'] : 'unknown',
+    'cache_hit'    => isset( $headers['x-rack-cache'] ) ? $headers['x-rack-cache'] : 'unknown',
+    'runtime'      => isset( $headers['x-runtime'] )    ? $headers['x-runtime']    : 'unknown',
+    'content_type' => isset( $headers['content-type'])  ? $headers['content-type'] : 'unknown',
+  );
+}
+
+function memberful_wp_error_log() {
+  return get_option( 'memberful_error_log', array() );
+}
+
+function memberful_wp_record_wp_error( $wp_error ) {
+  return memberful_wp_record_error(array(
+    'codes'    => $wp_error->get_error_codes(),
+    'messages' => $wp_error->get_error_messages(),
+    'data'     => $wp_error->get_error_data()
+  ));
+}
+
+function memberful_wp_record_error( $new_payload ) {
+  if ( ! isset( $new_payload['caller'] ) ) {
+    $new_payload['caller'] = array_map('memberful_wp_strip_args_from_backtrace', array_slice(debug_backtrace(), 1, 10));
+  }
+
+  if ( ! isset( $new_payload['date'] ) ) {
+    $new_payload['date'] = gmdate('c');
+  }
+
+  return memberful_wp_store_error( $new_payload );
+}
+
+function memberful_wp_strip_args_from_backtrace( $line ) {
+  unset($line['args']);
+
+  return $line;
+}
+
+function memberful_wp_store_error( $new_payload ) {
+  // Try not to overload the WP options table with errors!
+  $error_log = array_slice( memberful_wp_error_log(), 0, 99, TRUE );
+
+  array_unshift( $error_log, $new_payload );
+
+  update_option( 'memberful_error_log', $error_log );
+
+  return true;
+}
+
+

--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -169,6 +169,7 @@ class Memberful_Authenticator {
     $response = memberful_wp_post_data_to_api_as_json( self::oauth_member_url('token'), $params );
 
     if ( is_wp_error($response) ) {
+      memberful_wp_record_wp_error( $response );
       return $this->_error( 'could_not_get_tokens', $response );
     }
 
@@ -181,6 +182,8 @@ class Memberful_Authenticator {
         'error' => 'Could not get access token from Memberful',
         'response' => $response
       );
+
+      memberful_wp_record_error( $payload );
 
       return $this->_error(
         $payload['code'],

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints.php
@@ -5,8 +5,9 @@
  */
 
 require MEMBERFUL_DIR . '/src/endpoints/auth.php';
-require MEMBERFUL_DIR . '/src/endpoints/set_test_cookie.php';
 require MEMBERFUL_DIR . '/src/endpoints/check_test_cookie.php';
+require MEMBERFUL_DIR . '/src/endpoints/debug.php';
+require MEMBERFUL_DIR . '/src/endpoints/set_test_cookie.php';
 require MEMBERFUL_DIR . '/src/endpoints/webhook.php';
 
 add_action( 'plugins_loaded', 'memberful_wp_endpoint_filter' );
@@ -49,6 +50,9 @@ function memberful_wp_endpoint_for_request() {
       break;
     case 'webhook':
       $endpoint = new Memberful_Wp_Endpoint_Webhook;
+      break;
+    case 'debug':
+      $endpoint = new Memberful_Wp_Endpoint_Debug;
       break;
     }
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/debug.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/debug.php
@@ -1,0 +1,44 @@
+<?php
+
+class Memberful_Wp_Endpoint_Debug implements Memberful_Wp_Endpoint {
+  public function verify_request( $request_method ) {
+    if(!is_ssl())
+      return false;
+
+    if($request_method !== "GET")
+      return false;
+
+    $memberful_api_key = get_option( "memberful_api_key" );
+
+    if( empty( $memberful_api_key ) )
+      return false;
+
+    $headers = getallheaders();
+
+    if(!isset( $headers["X-Memberful-Api-Key"] ))
+      return false;
+
+    if($headers["X-Memberful-Api-Key"] != $memberful_api_key)
+      return false;
+
+    return true;
+  }
+
+  public function process( array $request_params, array $server_params ) {
+    $mapping_stats = new Memberful_User_Map_Stats(Memberful_User_Mapping_Repository::table());
+    $unmapped_users = $mapping_stats->unmapped_users();
+
+    if( count($unmapped_users) > 0 ) {
+      echo "Unmapped users:\n";
+      echo str_pad('WP ID', 6), ' ', str_pad('Email', 30), ' ', "Date registered\n";
+      foreach($unmapped_users as $unmapped_user) {
+        echo str_pad($unmapped_user->ID, 6), ' ', str_pad($unmapped_user->user_email, 30), ' ', $unmapped_user->user_registered, "\n";
+      }
+      echo "\n";
+    }
+
+    echo "Error log:\n";
+    var_export( memberful_wp_error_log() );
+    exit;
+  }
+}

--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -8,6 +8,10 @@ function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context =
   $account = memberful_api_member( $member_id );
 
   if ( is_wp_error( $account ) ) {
+    memberful_wp_record_error(array(
+      'error'  => $account->get_error_messages()
+    ));
+
     return $account;
   }
 
@@ -45,6 +49,11 @@ function memberful_wp_sync_member_account( $account, $mapping_context ) {
     $wpdb->query( "COMMIT" );
   } else {
     $wpdb->query( "ROLLBACK" );
+    memberful_wp_record_error(array(
+      'error' => $user->get_error_messages(),
+      'code'  => $user->get_error_code(),
+      'member_email' => $account->member->email
+    ));
   }
 
   return $user;

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -104,6 +104,10 @@ class Memberful_User_Map {
 
     if ( is_wp_error( $outcome_of_mapping ) ) {
       if ( $outcome_of_mapping->get_error_code() === "duplicate_user_for_member" && ! $wp_user_existed_before_request ) {
+        // We only record this error as others will be passed up and recorded
+        // by something else, whereas here we're working around the error.
+        memberful_wp_record_wp_error( $outcome_of_mapping );
+
         wp_delete_user( $wp_user->ID );
 
         $error_data = $outcome_of_mapping->get_error_data();


### PR DESCRIPTION
Changes in this PR:

- Add back debug logging which was removed in a2531b05980d434610549c1071e0f26f9251a1ba. The main difference is that now we use `debug_print_backtrace` instead of `debug_backtrace` to avoid possible serialization issues when we store the error in the database.
- Add possibility to remotely access the debug information. See a4d0ef48b5e78845e656a6ba19b4854f40f30b1b for details.