### PR TITLE
Call memberful_wp_endpoint_filter later

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -48,6 +48,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= Development =
+
+* Improve member synchronization with Memberful.
+
 = 1.33.0 =
 
 * Make debugging of plugin issues easier.

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints.php
@@ -10,7 +10,7 @@ require MEMBERFUL_DIR . '/src/endpoints/debug.php';
 require MEMBERFUL_DIR . '/src/endpoints/set_test_cookie.php';
 require MEMBERFUL_DIR . '/src/endpoints/webhook.php';
 
-add_action( 'plugins_loaded', 'memberful_wp_endpoint_filter' );
+add_action( 'wp_loaded', 'memberful_wp_endpoint_filter' );
 
 /**
  * Listens to all requests and checks to see if the user is trying to access one of


### PR DESCRIPTION
When we called `wp_update_user()` and user password changed, then
`wp_update_user()` called `switch_to_locale()` which then called
`$wp_locale_switcher->switch_to_locale()` which failed because
`$wp_locale_switcher` is defined in `wp-settings.php` which wasn't
loaded yet.

This caused webhook failures for members with updated emails and also
login issues for the same members. This commit fixes the issue by
calling `memberful_wp_endpoint_filter` after WordPress initialization
from the `wp_loaded` hook.