### PR TITLE
Fix products getting swept up in global the_content protection

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -3,7 +3,7 @@
 Plugin Name: Memberful WP
 Plugin URI: http://github.com/memberful/memberful-wp
 Description: Sell memberships and restrict access to content with WordPress and Memberful.
-Version: 1.36.0
+Version: 1.36.1
 Author: Memberful
 Author URI: http://memberful.com
 License: GPLv2 or later

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -3,7 +3,7 @@ Contributors: matt-button, drewstrojny, dwestendorf, rusuandreirobert, sumobi, W
 Tags: memberful, member, membership, memberships, recurring payments, recurring billing, paywall, subscriptions, stripe, oauth, oauth2
 Requires at least: 3.6
 Tested up to: 4.9
-Stable tag: 1.36.0
+Stable tag: 1.36.1
 License: GPLv2 or later
 
 Sell memberships and restrict access to content with WordPress and Memberful.
@@ -47,6 +47,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 3. Simple sign in and account management widget.
 
 == Changelog ==
+
+= 1.36.1 =
+
+* Fixes Sensei integration global targetting of content via the_content
 
 = 1.36.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
@@ -38,7 +38,7 @@ class Memberful_Wp_Integration_WooCommerce {
    * Archive (loop) pages
    */
   function is_purchasable( $purchasable, $product ) {
-    return !current_user_can('administrator') && !memberful_can_user_access_post( get_current_user_id(), $product->get_id() ) ? false : $purchasable;
+    return !memberful_is_admin( wp_get_current_user() ) && !memberful_can_user_access_post( get_current_user_id(), $product->get_id() ) ? false : $purchasable;
   }
 
   /**
@@ -47,7 +47,7 @@ class Memberful_Wp_Integration_WooCommerce {
   function hide_add_to_cart_button() {
     global $post;
 
-    if (!current_user_can('administrator') && !memberful_can_user_access_post( get_current_user_id(), $post->ID ) ) {
+    if ( !memberful_is_admin( wp_get_current_user() ) && !memberful_can_user_access_post( get_current_user_id(), $post->ID ) ) {
       remove_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30 );
       echo $this->memberful_wp_protect_woo_content( $post->ID );
     }
@@ -62,7 +62,7 @@ class Memberful_Wp_Integration_WooCommerce {
    * @return bool
    */
   function block_cart_add( $passed, $product_id, $quantity ) {
-    if (!current_user_can('administrator') && !memberful_can_user_access_post( get_current_user_id(), $product_id ) ) {
+    if ( !memberful_is_admin( wp_get_current_user() ) && !memberful_can_user_access_post( get_current_user_id(), $product_id ) ) {
       wc_add_notice( $this->memberful_wp_protect_woo_content( $product_id ), 'error' );
       return false;
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
@@ -18,15 +18,27 @@ class Memberful_Wp_Integration_WooCommerce {
   function __construct() {
     add_action( 'woocommerce_single_product_summary', array( $this, 'hide_add_to_cart_button' ), 25);
     add_filter( 'woocommerce_add_to_cart_validation', array( $this, 'block_cart_add' ), 30, 3 );
-    add_filter( 'woocommerce_is_purchasable', array( $this, 'not_purchasable'), 20, 2 );
+    add_filter( 'woocommerce_is_purchasable', array( $this, 'is_purchasable'), 20, 2 );
+    add_filter( 'the_content', array( $this, 'remove_erroneous_protection' ), -20 );
+  }
+
+  /**
+   * Removes filtering on the content from other functionalities
+   */
+  function remove_erroneous_protection( $content ) {
+    global $post;
+    if ($post->post_type == "product") {
+      remove_filter( 'the_content', 'memberful_wp_protect_content', -10 );
+    }
+    return $content;
   }
 
   /**
    * Makes it so that the add to cart button on archive page will show Read More and link to product on
    * Archive (loop) pages
    */
-  function not_purchasable( $purchasable, $product ) {
-    return !memberful_can_user_access_post( get_current_user_id(), $product->get_id() ) ? false : $purchasable;
+  function is_purchasable( $purchasable, $product ) {
+    return !current_user_can('administrator') && !memberful_can_user_access_post( get_current_user_id(), $product->get_id() ) ? false : $purchasable;
   }
 
   /**
@@ -35,7 +47,7 @@ class Memberful_Wp_Integration_WooCommerce {
   function hide_add_to_cart_button() {
     global $post;
 
-    if (!memberful_can_user_access_post( get_current_user_id(), $post->ID ) ) {
+    if (!current_user_can('administrator') && !memberful_can_user_access_post( get_current_user_id(), $post->ID ) ) {
       remove_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_add_to_cart', 30 );
       echo $this->memberful_wp_protect_woo_content( $post->ID );
     }
@@ -50,7 +62,7 @@ class Memberful_Wp_Integration_WooCommerce {
    * @return bool
    */
   function block_cart_add( $passed, $product_id, $quantity ) {
-    if (!memberful_can_user_access_post( get_current_user_id(), $product_id ) ) {
+    if (!current_user_can('administrator') && !memberful_can_user_access_post( get_current_user_id(), $product_id ) ) {
       wc_add_notice( $this->memberful_wp_protect_woo_content( $product_id ), 'error' );
       return false;
     }


### PR DESCRIPTION
Pulled in latest changes from main fork and then pushed this fix on top