### PR TITLE
Fix the Restrict Content Tool for WooCommerce

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -48,6 +48,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased version =
+
+* Fix "Restrict Content Tool" for WooCommerce products.
+
 = 1.38.0 =
 
 * Add support for Elementor page builder.

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
@@ -19,18 +19,6 @@ class Memberful_Wp_Integration_WooCommerce {
     add_action( 'woocommerce_single_product_summary', array( $this, 'hide_add_to_cart_button' ), 25);
     add_filter( 'woocommerce_add_to_cart_validation', array( $this, 'block_cart_add' ), 30, 3 );
     add_filter( 'woocommerce_is_purchasable', array( $this, 'is_purchasable'), 20, 2 );
-    add_filter( 'the_content', array( $this, 'remove_erroneous_protection' ), -20 );
-  }
-
-  /**
-   * Removes filtering on the content from other functionalities
-   */
-  function remove_erroneous_protection( $content ) {
-    global $post;
-    if ($post->post_type == "product") {
-      remove_filter( 'the_content', 'memberful_wp_protect_content', -10 );
-    }
-    return $content;
   }
 
   /**


### PR DESCRIPTION
The Restrict Content Tool was disabled on WooCommerce product pages.
However this doesn't make much sense because it can be disabled via
admin dashboard for a given product (or not enabled at all for). I think
that this filter was added by mistake and in real we wanted to disable
WooCommerce filters in order to make our Restrict Content Tool work with
WooCommerce.