### PR TITLE
Add support for WordPress 5.0

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: matt-button, drewstrojny, dwestendorf, rusuandreirobert, sumobi, Webby Scots
 Tags: memberful, member, membership, memberships, recurring payments, recurring billing, paywall, subscriptions, stripe, oauth, oauth2
 Requires at least: 3.6
-Tested up to: 4.9
+Tested up to: 5.0
 Stable tag: 1.43.1
 License: GPLv2 or later
 

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -48,6 +48,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Add basic support for WordPress 5.0.
+
 = 1.43.1 =
 
 * Fix for WP Ultimate Recipe Premium integration.

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -21,7 +21,10 @@ function memberful_wp_add_metabox() {
       'memberful_acl',
       'Memberful: Restrict Access',
       'memberful_wp_metabox',
-      $type
+      $type,
+      'advanced',
+      'default',
+      array('__block_editor_compatible_meta_box' => false)
     );
   }
 }


### PR DESCRIPTION
This pull request just enforces the Classic Editor for our meta box because https://github.com/WordPress/gutenberg/issues/7176 is still not fixed. Once it is fixed, we can enable our meta box for the new editor.

<img width="1055" alt="screenshot 2018-12-05 at 10 43 25" src="https://user-images.githubusercontent.com/522375/49505295-bc61ec00-f87b-11e8-9208-ccde18395caf.png">
