### PR TITLE
Do not install ari-adminer

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -54,7 +54,6 @@ db_pass: wordpress
 # Plugin's slug or url to the plugin's slug.
 #
 plugins:
-  - ari-adminer
   - verify-domain-for-apple-pay-with-stripe
   - wordpress-beta-tester
 


### PR DESCRIPTION
Unfortunately this plugin was [recently removed][1] from the plugin repo and I don't see any replacement which adds [adminer][2] to WordPress.

[1]: https://wordpress.org/plugins/ari-adminer/
[2]: https://www.adminer.org/