### PR TITLE
Use elementor/frontend/the_content hook to protect content

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/elementor.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/elementor.php
@@ -1,13 +1,3 @@
 <?php
-use Elementor\Plugin;
 
-add_action( 'wp', 'memberful_disable_elementor_content_filter' );
-
-function memberful_disable_elementor_content_filter() {
-  global $post;
-
-  if ( ! memberful_can_user_access_post( wp_get_current_user()->ID, $post->ID ) ) {
-    $elementor = Plugin::instance();
-    $elementor->frontend->remove_content_filter();
-  }
-}
+add_action('elementor/frontend/the_content', 'memberful_wp_protect_content');


### PR DESCRIPTION
Fixes an error message displayed in the WP admin when both
the Memberful and Elementor are installed.

https://code.elementor.com/php-hooks/#elementorfrontendthe_content