### PR TITLE
Use BIGINT(20) for IDs and timestamps

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -48,6 +48,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased version =
+
+* Improve plugin's internal database table structure.
+
 = 1.47.0 =
 
 * Improve support for Elementor page builder.

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -22,10 +22,10 @@ function memberful_wp_plugin_migrate_db() {
   if ( $db_version < 1 ) {
     $result = $wpdb->query(
       'CREATE TABLE `'.Memberful_User_Mapping_Repository::table().'`(
-        `wp_user_id` INT UNSIGNED NULL DEFAULT NULL UNIQUE KEY,
-        `member_id` INT UNSIGNED NOT NULL PRIMARY KEY,
+        `wp_user_id` BIGINT(20) UNSIGNED NULL DEFAULT NULL UNIQUE KEY,
+        `member_id` BIGINT(20) UNSIGNED NOT NULL PRIMARY KEY,
         `refresh_token` VARCHAR( 45 ) NULL DEFAULT NULL,
-        `last_sync_at` INT UNSIGNED NOT NULL DEFAULT 0)'
+        `last_sync_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0)'
       );
 
     if ( $result === false ) {


### PR DESCRIPTION
[WordPress uses BIGINT(20) for all IDs][1], therefore we should use it in our foreign keys, too. Also, I've decided to update `member_id` and [`last_sync_at`][2], too, to make our table future proof.

[1]: https://codex.wordpress.org/Database_Description
[2]: https://en.wikipedia.org/wiki/Year_2038_problem