### PR TITLE
Mark restricted posts in admin for subscriber-only

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -3,14 +3,14 @@
 Plugin Name: Memberful WP
 Plugin URI: http://github.com/memberful/memberful-wp
 Description: Sell memberships and restrict access to content with WordPress and Memberful.
-Version: 1.49.0
+Version: 1.49.1
 Author: Memberful
 Author URI: http://memberful.com
 License: GPLv2 or later
  */
 
 if ( ! defined( 'MEMBERFUL_VERSION' ) )
-  define( 'MEMBERFUL_VERSION', '1.49.0' );
+  define( 'MEMBERFUL_VERSION', '1.49.1' );
 
 if ( ! defined( 'MEMBERFUL_PLUGIN_FILE' ) )
   define( 'MEMBERFUL_PLUGIN_FILE', __FILE__ );

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -3,7 +3,7 @@ Contributors: matt-button, drewstrojny, dwestendorf, rusuandreirobert, sumobi, W
 Tags: memberful, member, membership, memberships, recurring payments, recurring billing, paywall, subscriptions, stripe, oauth, oauth2
 Requires at least: 3.6
 Tested up to: 5.2
-Stable tag: 1.49.0
+Stable tag: 1.49.1
 License: GPLv2 or later
 
 Sell memberships and restrict access to content with WordPress and Memberful.
@@ -47,6 +47,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 3. Simple sign in and account management widget.
 
 == Changelog ==
+
+= 1.49.1 =
+
+* Add missing "Protected by Memberful" message alongside posts restricted to registered members or members with any active subscription.
 
 = 1.49.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -535,8 +535,9 @@ function memberful_wp_announce_plans_and_download_in_head() {
 
 function memberful_wp_add_protected_state_to_post_list($states, $post) {
   $ids_of_protected_posts = memberful_wp_posts_that_are_protected();
+  $restricted_to_subscribers = memberful_wp_get_post_available_to_anybody_subscribed_to_a_plan( $post->ID );
 
-  if ( in_array( $post->ID, $ids_of_protected_posts ) ) {
+  if ( in_array( $post->ID, $ids_of_protected_posts ) || $restricted_to_subscribers ) {
     $states[] = __('Protected by Memberful');
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -535,9 +535,12 @@ function memberful_wp_announce_plans_and_download_in_head() {
 
 function memberful_wp_add_protected_state_to_post_list($states, $post) {
   $ids_of_protected_posts = memberful_wp_posts_that_are_protected();
-  $restricted_to_subscribers = memberful_wp_get_post_available_to_anybody_subscribed_to_a_plan( $post->ID );
 
-  if ( in_array( $post->ID, $ids_of_protected_posts ) || $restricted_to_subscribers ) {
+  $restricted_to_specific_plan = in_array( $post->ID, $ids_of_protected_posts );
+  $restricted_to_any_subscribers = memberful_wp_get_post_available_to_anybody_subscribed_to_a_plan( $post->ID );
+  $restricted_to_any_registered_users = memberful_wp_get_post_available_to_any_registered_users( $post->ID );
+
+  if ( $restricted_to_specific_plan || $restricted_to_any_subscribers || $restricted_to_any_registered_users ) {
     $states[] = __('Protected by Memberful');
   }
 


### PR DESCRIPTION
Ensure the "Protected by Memberful" message is displayed in the admin
posts list on posts that are restricted to any member with an active
subscription.

This is in addition to the current logic that displays the notice only
if a post is restricted to subscribers of a specific plan.