### PR TITLE
Only restrict main content on Elementor pages

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -3,14 +3,14 @@
 Plugin Name: Memberful WP
 Plugin URI: http://github.com/memberful/memberful-wp
 Description: Sell memberships and restrict access to content with WordPress and Memberful.
-Version: 1.49.1
+Version: 1.49.2
 Author: Memberful
 Author URI: http://memberful.com
 License: GPLv2 or later
  */
 
 if ( ! defined( 'MEMBERFUL_VERSION' ) )
-  define( 'MEMBERFUL_VERSION', '1.49.1' );
+  define( 'MEMBERFUL_VERSION', '1.49.2' );
 
 if ( ! defined( 'MEMBERFUL_PLUGIN_FILE' ) )
   define( 'MEMBERFUL_PLUGIN_FILE', __FILE__ );

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -3,7 +3,7 @@ Contributors: matt-button, drewstrojny, dwestendorf, rusuandreirobert, sumobi, W
 Tags: memberful, member, membership, memberships, recurring payments, recurring billing, paywall, subscriptions, stripe, oauth, oauth2
 Requires at least: 3.6
 Tested up to: 5.2
-Stable tag: 1.49.1
+Stable tag: 1.49.2
 License: GPLv2 or later
 
 Sell memberships and restrict access to content with WordPress and Memberful.
@@ -47,6 +47,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 3. Simple sign in and account management widget.
 
 == Changelog ==
+
+= 1.49.2 =
+
+* Fix a compatibility issue with the Elementor plugin that caused Memberful to restrict more than just the main post content.
 
 = 1.49.1 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -14,7 +14,7 @@ function memberful_wp_protect_content( $content ) {
     remove_action( "the_content", "FLBuilder::render_content" );
 
     // Remove Elementor action hook
-    remove_action("elementor/frontent/the_content", "memberful_wp_protect_content");
+    remove_action("elementor/frontend/the_content", "memberful_wp_protect_content");
 
     // Remove media enclosures from the RSS feed
     add_filter("rss_enclosure", "__return_empty_string");

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -13,6 +13,9 @@ function memberful_wp_protect_content( $content ) {
     // Disable Beaver Builder
     remove_action( "the_content", "FLBuilder::render_content" );
 
+    // Remove Elementor action hook
+    remove_action("elementor/frontent/the_content", "memberful_wp_protect_content");
+
     // Remove media enclosures from the RSS feed
     add_filter("rss_enclosure", "__return_empty_string");
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/elementor.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/elementor.php
@@ -1,3 +1,8 @@
 <?php
 
-add_action('elementor/frontend/the_content', 'memberful_wp_protect_content');
+add_filter('elementor/frontend/builder_content_data', function($data, $post_id) {
+  if (get_queried_object_id() === $post_id) {
+    add_action('elementor/frontend/the_content', 'memberful_wp_protect_content');
+  }
+  return $data;
+}, 10, 2);


### PR DESCRIPTION
This fix ensures the restricted content filter is only removing content
in the main page or post body when running with Elementor themes.

https://github.com/elementor/elementor/issues/8930