### PR TITLE
Allow category filtering on the private feeds

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
@@ -102,7 +102,7 @@ function memberful_private_rss_feed_link($success_message = '', $error_message =
   $link = (get_home_url() . '/' . memberful_private_user_feed_get_url_identifier($feedToken) );
 
   if($category)
-    $link .= '&category=' . $category;
+    $link = add_query_arg('category', $category, $link);
 
   if($success_message != '')
     $link = '<a href="' . $link . '">' . do_shortcode($success_message) . '</a>';

--- a/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
@@ -21,10 +21,7 @@ function memberful_private_user_feed_init() {
     return;
 
   // Extract the token from the URL
-  $feedUserToken = substr($_SERVER['REQUEST_URI'],
-    strpos($_SERVER['REQUEST_URI'], memberful_private_user_feed_get_url_identifier())
-    + strlen(memberful_private_user_feed_get_url_identifier())
-  );
+  $feedUserToken = $_GET['member-feed'];
 
   $requiredPlan = memberful_private_user_feed_settings_get_required_plan();
 
@@ -78,7 +75,7 @@ function memberful_private_user_feed_deliver() {
  * @param bool $return
  * @return string
  */
-function memberful_private_rss_feed_link($success_message = '', $error_message = "You don’t have access to this RSS feed.", $return = false) {
+function memberful_private_rss_feed_link($success_message = '', $error_message = "You don’t have access to this RSS feed.", $return = false, $category = false) {
   $error_message = apply_filters( 'memberful_private_rss_feed_error_message', $error_message );
 
   if(!is_user_logged_in())
@@ -103,6 +100,9 @@ function memberful_private_rss_feed_link($success_message = '', $error_message =
   }
 
   $link = (get_home_url() . '/' . memberful_private_user_feed_get_url_identifier($feedToken) );
+
+  if($category)
+    $link .= '&category=' . $category;
 
   if($success_message != '')
     $link = '<a href="' . $link . '">' . do_shortcode($success_message) . '</a>';

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -129,7 +129,9 @@ function memberful_wp_shortcode( $atts, $content ) {
 }
 
 function memberful_wp_shortcode_private_user_feed_link($atts = array(), $content = '') {
-  return memberful_private_rss_feed_link($content, __("You don’t have access to this RSS feed."), true);
+  $category = $atts['category'] ?? '';
+
+  return memberful_private_rss_feed_link($content, __("You don’t have access to this RSS feed."), true, $category);
 }
 
 function memberful_wp_slugs_to_ids( $slugs ) {

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
@@ -10,9 +10,11 @@ remove_all_filters('the_excerpt_rss');
 remove_filter('the_content', 'memberful_wp_protect_content', -10);
 
 $post_types = array("post");
+$category = $_GET['category'] ?? '';
 
 query_posts(array(
   'category__in'    => apply_filters( 'memberful_private_rss_category_ids', array() ),
+  'category_name'   => $category,
   'post_type'       => apply_filters( 'memberful_private_rss_post_types', $post_types ),
   'posts_per_page'  => get_option( 'posts_per_rss', 10 )
 ));


### PR DESCRIPTION
Add ability to filter by category on the private member feed, using a
new parameter that can be used with the private feed shortcode.

For example:
[memberful_private_rss_feed_link category="news"]

No category parameter preserves current behaviour of listing all posts
the users has access to.