### PR TITLE
Add block tags to feed

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -502,8 +502,10 @@ function memberful_wp_protect_bbpress() {
 function memberful_wp_private_rss_feed_settings() {
   if(isset($_POST['memberful_private_feed_subscriptions_submit'])) {
     $private_feed_subscriptions = isset($_POST['memberful_private_feed_subscriptions']) ? $_POST['memberful_private_feed_subscriptions'] : false;
+    $add_block_tags = isset($_POST['memberful_add_block_tags_to_rss_feed']);
 
     memberful_private_user_feed_settings_set_required_plan($private_feed_subscriptions);
+    update_option('memberful_add_block_tags_to_rss_feed', $add_block_tags);
   }
 
   $current_feed_subscriptions = memberful_private_user_feed_settings_get_required_plan();
@@ -512,10 +514,11 @@ function memberful_wp_private_rss_feed_settings() {
   memberful_wp_render(
     'private_user_feed_settings',
     array(
-      'form_target'               => memberful_wp_plugin_private_user_feed_settings_url(),
-      'subscription_plans'        => memberful_subscription_plans(),
-      'available_subscriptions'   => memberful_private_user_feed_settings_get_required_plan(),
-      'current_feed_subscriptions'=> $current_feed_subscriptions
+      'form_target'                => memberful_wp_plugin_private_user_feed_settings_url(),
+      'subscription_plans'         => memberful_subscription_plans(),
+      'available_subscriptions'    => memberful_private_user_feed_settings_get_required_plan(),
+      'current_feed_subscriptions' => $current_feed_subscriptions,
+      'add_block_tags_to_rss_feed' => get_option('memberful_add_block_tags_to_rss_feed')
     )
   );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -209,3 +209,6 @@ Private RSS Feeds
 .postbox.memberful-private-feed-instructions code {
   font-size: 12px;
 }
+.memberful-add-block-tags {
+  margin-bottom: 6.5px;
+}

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -151,6 +151,7 @@ p.memberful-access-header {
 .memberful-access-label__text--multiline {
   display: block;
   margin-left: 25px;
+  line-height: 1.4em;
 }
 .memberful-marketing-content {
   float: left;
@@ -210,5 +211,5 @@ Private RSS Feeds
   font-size: 12px;
 }
 .memberful-add-block-tags {
-  margin-bottom: 6.5px;
+  margin: 15px 0;
 }

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
@@ -30,6 +30,10 @@ do_action( 'rss_tag_pre', 'rss2' );
      xmlns:atom="http://www.w3.org/2005/Atom"
      xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
      xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+    <?php if(get_option('memberful_add_block_tags_to_rss_feed')): ?>
+      xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+      xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
+    <?php endif; ?>
     <?php do_action('rss2_ns'); ?>>
   <channel>
     <title><?php bloginfo_rss('name'); ?> Member Feed</title>
@@ -38,6 +42,10 @@ do_action( 'rss_tag_pre', 'rss2' );
     <description><?php bloginfo_rss("description") ?></description>
     <lastBuildDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_lastpostmodified('GMT'), false); ?></lastBuildDate>
     <language><?php bloginfo_rss( 'language' ); ?></language>
+    <?php if (get_option('memberful_add_block_tags_to_rss_feed')): ?>
+      <itunes:block>Yes</itunes:block>
+      <googleplay:block>yes</googleplay:block>
+    <?php endif; ?>
     <sy:updatePeriod><?php
 $duration = 'hourly';
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_settings.php
@@ -30,9 +30,9 @@
             <?php endif; ?>
             <hr>
             <div class="memberful-add-block-tags">
-              <label for="memberful_add_block_tags_to_rss_feed">
-                <input id="memberful_add_block_tags_to_rss_feed" type="checkbox" name="memberful_add_block_tags_to_rss_feed" <?php if( $add_block_tags_to_rss_feed ): ?>checked="checked"<?php endif; ?>>
-                Hide feed from iTunes and Google Podcasts.
+              <label for="memberful_add_block_tags_to_rss_feed" class="memberful-access-label">
+                <input id="memberful_add_block_tags_to_rss_feed" type="checkbox" name="memberful_add_block_tags_to_rss_feed" class="memberful-access-label__checkbox--multiline" <?php if( $add_block_tags_to_rss_feed ): ?>checked="checked"<?php endif; ?>>
+                <span class="memberful-access-label__text--multiline">Block private RSS feeds from the iTunes and Google podcast directories.</span>
               </label>
             </div>
             <input type="submit" name="memberful_private_feed_subscriptions_submit" class="button button-primary" value="<?php _e( "Save Changes", 'memberful' ); ?>" />

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_settings.php
@@ -28,6 +28,13 @@
             <?php else : ?>
               <p class="memberful-private-feed-error"><?php _e( "There are no available Subscription Plans.", 'memberful' ); ?></p>
             <?php endif; ?>
+            <hr>
+            <div class="memberful-add-block-tags">
+              <label for="memberful_add_block_tags_to_rss_feed">
+                <input id="memberful_add_block_tags_to_rss_feed" type="checkbox" name="memberful_add_block_tags_to_rss_feed" <?php if( $add_block_tags_to_rss_feed ): ?>checked="checked"<?php endif; ?>>
+                Hide feed from iTunes and Google Podcasts.
+              </label>
+            </div>
             <input type="submit" name="memberful_private_feed_subscriptions_submit" class="button button-primary" value="<?php _e( "Save Changes", 'memberful' ); ?>" />
           </fieldset>
         </div>


### PR DESCRIPTION
* 04ea560 **Add itunes/gpodcasts block tags to private feed**
  
  By default, iTunes and Google Podcasts index all feeds they encounter.
  Since we offer private feeds, this is not intended behavior. As a way to
  prevent this, we can add some tags that forbid feed indexing.
  
  For iTunes, we should add the <itunes:block> [tag](https://help.apple.com/itc/podcasts_connect/?lang=en#/itcb54353390).
  For Google Podcasts, we should add the <googleplay:block> [tag](https://developers.google.com/search/docs/guides/podcast-management#remove).

* 86fd2f4  **Add opt-in setting to include block tags in feed**
  
  Instead of adding the block tags (04ea560f7b1338f03e5b9b43e1810e61ba7ea8c0) by default,
  we'll use an opt-in setting in the plugin page to control that.

Related to: https://3.basecamp.com/3293071/buckets/5610677/todos/1592569560