### PR TITLE
Document PHP requirements in readme.txt

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -3,6 +3,7 @@ Contributors: matt-button, drewstrojny, dwestendorf, rusuandreirobert, sumobi, W
 Tags: memberful, member, membership, memberships, recurring payments, recurring billing, paywall, subscriptions, stripe, oauth, oauth2
 Requires at least: 3.6
 Tested up to: 5.3
+Requires PHP: 7.0
 Stable tag: 1.53.0
 License: GPLv2 or later
 


### PR DESCRIPTION
We require PHP 7.0 since e0dc0dbe2cba43338f9dd034e99c72b73b5712c3 because we use the `??` operator.

See also: https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#example-readme