### PR TITLE
Sync Podcasts

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
@@ -151,23 +151,23 @@
     );
   }
 
-  function insertPodcastUrl(editor) {
+  function insertFeedUrl(editor) {
     function handleDialogSubmit(editor, id) {
       editor.insertContent(
         "[memberful_podcast_url podcast='"+id+"']"
       );
     }
 
-    function podcastOptions(podcast) {
-      return {text: podcast.name, value: podcast.id};
+    function feedOptions(feed) {
+      return {text: feed.name, value: feed.id};
     };
 
-    var podcasts = window.MemberfulData.podcasts;
-    var podcastList = {
+    var feeds = window.MemberfulData.feeds;
+    var feedList = {
       name: "item",
       type: "listbox",
       label: "Podcast",
-      values: podcasts.map(podcastOptions)
+      values: feeds.map(feedOptions)
     };
 
     editor.windowManager.open({
@@ -175,7 +175,7 @@
       width: 350,
       height: 60,
       body: [
-        podcastList,
+        feedList,
       ],
       onSubmit: function(e) {
         handleDialogSubmit(editor, e.data.item);
@@ -213,8 +213,8 @@
 
       menu.push({text: 'Private RSS Feed link', onclick: function() { insertPrivateRSSFeedShortcode(editor); }});
 
-      if (window.MemberfulData.podcasts.length > 0) {
-        menu.push({text: 'Show Podcast URL', onclick: function() { insertPodcastUrl(editor); }});
+      if (window.MemberfulData.feeds.length > 0) {
+        menu.push({text: 'Show Podcast URL', onclick: function() { insertFeedUrl(editor); }});
       }
 
       editor.addButton('memberful_wp', {

--- a/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
@@ -151,6 +151,38 @@
     );
   }
 
+  function insertPodcastUrl(editor) {
+    function handleDialogSubmit(editor, id) {
+      editor.insertContent(
+        "[memberful_podcast_url podcast='"+id+"']"
+      );
+    }
+
+    function podcastOptions(podcast) {
+      return {text: podcast.name, value: podcast.id};
+    };
+
+    var podcasts = window.MemberfulData.podcasts;
+    var podcastList = {
+      name: "item",
+      type: "listbox",
+      label: "Podcast",
+      values: podcasts.map(podcastOptions)
+    };
+
+    editor.windowManager.open({
+      title: "Choose a podcast",
+      width: 350,
+      height: 60,
+      body: [
+        podcastList,
+      ],
+      onSubmit: function(e) {
+        handleDialogSubmit(editor, e.data.item);
+      }
+    });
+  }
+
   /* Register the buttons */
   tinymce.create('tinymce.plugins.memberful_wp', {
     init : function(editor, url) {
@@ -180,6 +212,8 @@
       menu.push({text: 'Free sign up link', onclick: function() { insertRegistrationShortcode(editor); }});
 
       menu.push({text: 'Private RSS Feed link', onclick: function() { insertPrivateRSSFeedShortcode(editor); }});
+
+      menu.push({text: 'Podcast URL', onclick: function() { insertPodcastUrl(editor); }});
 
       editor.addButton('memberful_wp', {
         type: 'menubutton',

--- a/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
@@ -213,7 +213,9 @@
 
       menu.push({text: 'Private RSS Feed link', onclick: function() { insertPrivateRSSFeedShortcode(editor); }});
 
-      menu.push({text: 'Podcast URL', onclick: function() { insertPodcastUrl(editor); }});
+      if (window.MemberfulData.podcasts.length > 0) {
+        menu.push({text: 'Show Podcast URL', onclick: function() { insertPodcastUrl(editor); }});
+      }
 
       editor.addButton('memberful_wp', {
         type: 'menubutton',

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -98,6 +98,10 @@ function memberful_wp_user_downloads( $user_id ) {
   return get_user_meta( $user_id, 'memberful_product', TRUE );
 }
 
+function memberful_wp_user_podcasts($user_id) {
+  return get_user_meta($user_id, 'memberful_feed', TRUE);
+}
+
 /**
  * Gets the plans that the member with $member_id is currently subscribed to
  * If the member had a subscription to a plan, but it has expired then it
@@ -150,6 +154,17 @@ function memberful_wp_user_has_downloads( $user_id, $required_downloads ) {
 
   foreach ( $required_downloads as $download ) {
     if ( isset( $downloads_user_has[ $download ] ) )
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+function memberful_wp_user_has_podcasts($user_id, $podcasts) {
+  $user_podcasts = memberful_wp_user_podcasts($user_id);
+
+  foreach ($podcasts as $podcast) {
+    if (isset($user_podcasts[$podcast]))
       return TRUE;
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -98,7 +98,7 @@ function memberful_wp_user_downloads( $user_id ) {
   return get_user_meta( $user_id, 'memberful_product', TRUE );
 }
 
-function memberful_wp_user_podcasts($user_id) {
+function memberful_wp_user_feeds($user_id) {
   return get_user_meta($user_id, 'memberful_feed', TRUE);
 }
 
@@ -160,11 +160,11 @@ function memberful_wp_user_has_downloads( $user_id, $required_downloads ) {
   return FALSE;
 }
 
-function memberful_wp_user_has_podcasts($user_id, $podcasts) {
-  $user_podcasts = memberful_wp_user_podcasts($user_id);
+function memberful_wp_user_has_feeds($user_id, $feeds) {
+  $user_feeds = memberful_wp_user_feeds($user_id);
 
-  foreach ($podcasts as $podcast) {
-    if (isset($user_podcasts[$podcast]))
+  foreach ($feeds as $feed) {
+    if (isset($user_feeds[$feed]))
       return TRUE;
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
@@ -84,6 +84,14 @@ function has_memberful_podcast($ids) {
   return memberful_wp_user_has_podcasts($user_id, $ids);
 }
 
+function memberful_wp_podcast_url($id) {
+  $user_id = wp_get_current_user()->ID;
+  $podcasts = memberful_wp_user_podcasts($user_id);
+
+  if (isset($podcasts[$id]))
+    return $podcasts[$id]["url"];
+}
+
 function memberful_wp_posts_that_are_protected() {
   static $post_ids = NULL;
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
@@ -75,6 +75,12 @@ function has_memberful_download( $slug, $user_id = NULL ) {
   return memberful_wp_user_has_downloads( $user_id, $required_downloads );
 }
 
+/**
+ * Check that the current member has at least one of the specified feeds
+ *
+ * @param string|array $ids ID of the feed the user should have. Can pass an array of IDs
+ * @return bool
+ */
 function has_memberful_feed($ids) {
   $user_id = wp_get_current_user()->ID;
   if (!is_array($ids)) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
@@ -75,6 +75,15 @@ function has_memberful_download( $slug, $user_id = NULL ) {
   return memberful_wp_user_has_downloads( $user_id, $required_downloads );
 }
 
+function has_memberful_podcast($ids) {
+  $user_id = wp_get_current_user()->ID;
+  if (!is_array($ids)) {
+    $ids = array($ids);
+  }
+
+  return memberful_wp_user_has_podcasts($user_id, $ids);
+}
+
 function memberful_wp_posts_that_are_protected() {
   static $post_ids = NULL;
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
@@ -75,21 +75,21 @@ function has_memberful_download( $slug, $user_id = NULL ) {
   return memberful_wp_user_has_downloads( $user_id, $required_downloads );
 }
 
-function has_memberful_podcast($ids) {
+function has_memberful_feed($ids) {
   $user_id = wp_get_current_user()->ID;
   if (!is_array($ids)) {
     $ids = array($ids);
   }
 
-  return memberful_wp_user_has_podcasts($user_id, $ids);
+  return memberful_wp_user_has_feeds($user_id, $ids);
 }
 
-function memberful_wp_podcast_url($id) {
+function memberful_wp_feed_url($id) {
   $user_id = wp_get_current_user()->ID;
-  $podcasts = memberful_wp_user_podcasts($user_id);
+  $feeds = memberful_wp_user_feeds($user_id);
 
-  if (isset($podcasts[$id]))
-    return $podcasts[$id]["url"];
+  if (isset($feeds[$id]))
+    return $feeds[$id]["url"];
 }
 
 function memberful_wp_posts_that_are_protected() {

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -128,6 +128,7 @@ function memberful_wp_register() {
       if ( $activation === TRUE ) {
         update_option( 'memberful_embed_enabled', TRUE );
         memberful_wp_sync_downloads();
+        memberful_wp_sync_podcasts();
         memberful_wp_sync_subscription_plans();
       }
       else {
@@ -234,6 +235,12 @@ function memberful_wp_options() {
 
     if ( isset( $_POST['manual_sync'] ) ) {
       if ( is_wp_error( $error = memberful_wp_sync_downloads() ) ) {
+        Memberful_Wp_Reporting::report( $error, 'error' );
+
+        return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
+      }
+
+      if ( is_wp_error( $error = memberful_wp_sync_podcasts() ) ) {
         Memberful_Wp_Reporting::report( $error, 'error' );
 
         return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
@@ -530,6 +537,7 @@ function memberful_wp_announce_plans_and_download_in_head() {
       'data' => array(
         'plans' => array_values(memberful_subscription_plans()),
         'downloads' => array_values(memberful_downloads()),
+        'podcasts' => array_values(memberful_podcasts()),
         'connectedToMemberful' => memberful_wp_is_connected_to_site(),
       )
     )

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -127,8 +127,7 @@ function memberful_wp_register() {
 
       if ( $activation === TRUE ) {
         update_option( 'memberful_embed_enabled', TRUE );
-        memberful_wp_sync_downloads();
-        memberful_wp_sync_feeds();
+        memberful_wp_sync_products();
         memberful_wp_sync_subscription_plans();
       }
       else {
@@ -234,13 +233,7 @@ function memberful_wp_options() {
       return;
 
     if ( isset( $_POST['manual_sync'] ) ) {
-      if ( is_wp_error( $error = memberful_wp_sync_downloads() ) ) {
-        Memberful_Wp_Reporting::report( $error, 'error' );
-
-        return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
-      }
-
-      if ( is_wp_error( $error = memberful_wp_sync_feeds() ) ) {
+      if ( is_wp_error( $error = memberful_wp_sync_products() ) ) {
         Memberful_Wp_Reporting::report( $error, 'error' );
 
         return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -128,7 +128,7 @@ function memberful_wp_register() {
       if ( $activation === TRUE ) {
         update_option( 'memberful_embed_enabled', TRUE );
         memberful_wp_sync_downloads();
-        memberful_wp_sync_podcasts();
+        memberful_wp_sync_feeds();
         memberful_wp_sync_subscription_plans();
       }
       else {
@@ -240,7 +240,7 @@ function memberful_wp_options() {
         return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
       }
 
-      if ( is_wp_error( $error = memberful_wp_sync_podcasts() ) ) {
+      if ( is_wp_error( $error = memberful_wp_sync_feeds() ) ) {
         Memberful_Wp_Reporting::report( $error, 'error' );
 
         return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
@@ -537,7 +537,7 @@ function memberful_wp_announce_plans_and_download_in_head() {
       'data' => array(
         'plans' => array_values(memberful_subscription_plans()),
         'downloads' => array_values(memberful_downloads()),
-        'podcasts' => array_values(memberful_podcasts()),
+        'feeds' => array_values(memberful_feeds()),
         'connectedToMemberful' => memberful_wp_is_connected_to_site(),
       )
     )

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -285,12 +285,14 @@ function memberful_wp_options() {
 
   $products = get_option( 'memberful_products', array() );
   $subscriptions = get_option( 'memberful_subscriptions', array() );
+  $feeds = get_option( 'memberful_feeds', array() );
   $extend_auth_cookie_expiration = get_option( 'memberful_extend_auth_cookie_expiration' );
 
   memberful_wp_render (
     'options',
     array(
       'products' => $products,
+      'feeds' => $feeds,
       'subscriptions' => $subscriptions,
       'extend_auth_cookie_expiration' => $extend_auth_cookie_expiration
     )

--- a/wordpress/wp-content/plugins/memberful-wp/src/cron.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/cron.php
@@ -36,6 +36,7 @@ function memberful_wp_cron_sync_entities() {
   echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=start\n</pre>";
 
   memberful_wp_sync_downloads();
+  memberful_wp_sync_podcasts();
   memberful_wp_sync_subscription_plans();
 
   echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";

--- a/wordpress/wp-content/plugins/memberful-wp/src/cron.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/cron.php
@@ -35,8 +35,7 @@ function memberful_wp_cron_sync_entities() {
 
   echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=start\n</pre>";
 
-  memberful_wp_sync_downloads();
-  memberful_wp_sync_feeds();
+  memberful_wp_sync_products();
   memberful_wp_sync_subscription_plans();
 
   echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";

--- a/wordpress/wp-content/plugins/memberful-wp/src/cron.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/cron.php
@@ -36,7 +36,7 @@ function memberful_wp_cron_sync_entities() {
   echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=start\n</pre>";
 
   memberful_wp_sync_downloads();
-  memberful_wp_sync_podcasts();
+  memberful_wp_sync_feeds();
   memberful_wp_sync_subscription_plans();
 
   echo "<pre>library=memberful_wp method=memberful_wp_cron_sync_entities at=finish\n</pre>";

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -34,9 +34,9 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
 
       echo 'Syncing downloads';
     } elseif ( strpos( $payload->event, 'feed' ) !== FALSE ) {
-      memberful_wp_sync_podcasts();
+      memberful_wp_sync_feeds();
 
-      echo 'Syncing podcasts';
+      echo 'Syncing feeds';
     } else {
       echo 'Ignoring webhook';
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -33,6 +33,10 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
       memberful_wp_sync_downloads();
 
       echo 'Syncing downloads';
+    } elseif ( strpos( $payload->event, 'feed' ) !== FALSE ) {
+      memberful_wp_sync_podcasts();
+
+      echo 'Syncing podcasts';
     } else {
       echo 'Ignoring webhook';
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -30,11 +30,11 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
 
       echo 'Syncing subscription plans';
     } elseif ( strpos( $payload->event, 'download' ) !== FALSE ) {
-      memberful_wp_sync_downloads();
+      memberful_wp_sync_products();
 
       echo 'Syncing downloads';
     } elseif ( strpos( $payload->event, 'feed' ) !== FALSE ) {
-      memberful_wp_sync_feeds();
+      memberful_wp_sync_products();
 
       echo 'Syncing feeds';
     } else {

--- a/wordpress/wp-content/plugins/memberful-wp/src/entities.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/entities.php
@@ -25,7 +25,7 @@ function memberful_downloads() {
   return get_option( 'memberful_products', array() );
 }
 
-function memberful_podcasts() {
+function memberful_feeds() {
   return get_option( 'memberful_feeds', array() );
 }
 
@@ -39,8 +39,8 @@ function memberful_wp_sync_downloads() {
   return memberful_wp_update_entities( 'memberful_products', $url );
 }
 
-function memberful_wp_sync_podcasts() {
-  $url = memberful_admin_podcasts_url();
+function memberful_wp_sync_feeds() {
+  $url = memberful_admin_feeds_url();
 
   return memberful_wp_update_entities( 'memberful_feeds', $url );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -61,8 +61,8 @@ function memberful_wp_shortcode_download_link( $atts, $content) {
 }
 
 function memberful_wp_shortcode_feed_url($atts) {
-  if (isset($atts['feed'])) {
-    $id = $atts['feed'];
+  if (isset($atts['podcast'])) {
+    $id = $atts['podcast'];
     return memberful_wp_feed_url($id);
   }
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -9,7 +9,7 @@ add_shortcode( 'memberful_private_rss_feed_link', 'memberful_wp_shortcode_privat
 add_shortcode( 'memberful_register_link', 'memberful_wp_shortcode_register_link' );
 add_shortcode( 'memberful_sign_in_link',  'memberful_wp_shortcode_sign_in_link' );
 add_shortcode( 'memberful_sign_out_link', 'memberful_wp_shortcode_sign_out_link' );
-add_shortcode( 'memberful_podcast_url', 'memberful_wp_shortcode_podcast_url' );
+add_shortcode( 'memberful_podcast_url', 'memberful_wp_shortcode_feed_url' );
 
 function memberful_wp_shortcode_buy_download_link( $atts, $content ) {
   $url = memberful_checkout_for_download_url(
@@ -60,10 +60,10 @@ function memberful_wp_shortcode_download_link( $atts, $content) {
   return '<a href="'.memberful_account_get_download_url( $atts['download'] ).'" rel="download">'.do_shortcode($content).'</a>';
 }
 
-function memberful_wp_shortcode_podcast_url($atts) {
-  if (isset($atts['podcast'])) {
-    $id = $atts['podcast'];
-    return memberful_wp_podcast_url($id);
+function memberful_wp_shortcode_feed_url($atts) {
+  if (isset($atts['feed'])) {
+    $id = $atts['feed'];
+    return memberful_wp_feed_url($id);
   }
 }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -9,6 +9,7 @@ add_shortcode( 'memberful_private_rss_feed_link', 'memberful_wp_shortcode_privat
 add_shortcode( 'memberful_register_link', 'memberful_wp_shortcode_register_link' );
 add_shortcode( 'memberful_sign_in_link',  'memberful_wp_shortcode_sign_in_link' );
 add_shortcode( 'memberful_sign_out_link', 'memberful_wp_shortcode_sign_out_link' );
+add_shortcode( 'memberful_podcast_url', 'memberful_wp_shortcode_podcast_url' );
 
 function memberful_wp_shortcode_buy_download_link( $atts, $content ) {
   $url = memberful_checkout_for_download_url(
@@ -57,6 +58,13 @@ function memberful_wp_shortcode_download_link( $atts, $content) {
     return $content;
 
   return '<a href="'.memberful_account_get_download_url( $atts['download'] ).'" rel="download">'.do_shortcode($content).'</a>';
+}
+
+function memberful_wp_shortcode_podcast_url($atts) {
+  if (isset($atts['podcast'])) {
+    $id = $atts['podcast'];
+    return memberful_wp_podcast_url($id);
+  }
 }
 
 function memberful_wp_normalize_shortcode_args( $atts ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -1,6 +1,6 @@
 <?php
 require_once MEMBERFUL_DIR.'/src/user/downloads.php';
-require_once MEMBERFUL_DIR.'/src/user/podcasts.php';
+require_once MEMBERFUL_DIR.'/src/user/feeds.php';
 require_once MEMBERFUL_DIR.'/src/user/subscriptions.php';
 
 function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context = array() ) {
@@ -39,13 +39,13 @@ function memberful_wp_sync_member_account( $account, $mapping_context ) {
         Memberful_User_Mapping_Repository::delete_mapping( $user->ID );
       } else {
         Memberful_Wp_User_Downloads::sync($user->ID, array());
-        Memberful_Wp_User_Podcasts::sync($user->ID, array());
+        Memberful_Wp_User_Feeds::sync($user->ID, array());
         Memberful_Wp_User_Subscriptions::sync($user->ID, array());
         Memberful_Wp_User_Role_Decision::ensure_user_role_is_correct( $user );
       }
     } else {
       Memberful_Wp_User_Downloads::sync($user->ID, $account->products);
-      Memberful_Wp_User_Podcasts::sync($user->ID, $account->feeds);
+      Memberful_Wp_User_Feeds::sync($user->ID, $account->feeds);
       Memberful_Wp_User_Subscriptions::sync($user->ID, $account->subscriptions);
       Memberful_Wp_User_Role_Decision::ensure_user_role_is_correct( $user );
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -1,5 +1,6 @@
 <?php
 require_once MEMBERFUL_DIR.'/src/user/downloads.php';
+require_once MEMBERFUL_DIR.'/src/user/podcasts.php';
 require_once MEMBERFUL_DIR.'/src/user/subscriptions.php';
 
 function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context = array() ) {
@@ -38,11 +39,13 @@ function memberful_wp_sync_member_account( $account, $mapping_context ) {
         Memberful_User_Mapping_Repository::delete_mapping( $user->ID );
       } else {
         Memberful_Wp_User_Downloads::sync($user->ID, array());
+        Memberful_Wp_User_Podcasts::sync($user->ID, array());
         Memberful_Wp_User_Subscriptions::sync($user->ID, array());
         Memberful_Wp_User_Role_Decision::ensure_user_role_is_correct( $user );
       }
     } else {
       Memberful_Wp_User_Downloads::sync($user->ID, $account->products);
+      Memberful_Wp_User_Podcasts::sync($user->ID, $account->feeds);
       Memberful_Wp_User_Subscriptions::sync($user->ID, $account->subscriptions);
       Memberful_Wp_User_Role_Decision::ensure_user_role_is_correct( $user );
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -40,7 +40,7 @@ function memberful_admin_downloads_url( $format = MEMBERFUL_HTML ) {
   return memberful_url( 'admin/products', $format );
 }
 
-function memberful_admin_podcasts_url( $format = MEMBERFUL_JSON ) {
+function memberful_admin_feeds_url( $format = MEMBERFUL_JSON ) {
   return memberful_url( 'admin/feeds', $format );
 }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -36,12 +36,8 @@ function memberful_admin_member_url( $member_id, $format = MEMBERFUL_HTML ) {
   return memberful_url( 'admin/members/'.$member_id, $format );
 }
 
-function memberful_admin_downloads_url( $format = MEMBERFUL_HTML ) {
+function memberful_admin_products_url( $format = MEMBERFUL_HTML ) {
   return memberful_url( 'admin/products', $format );
-}
-
-function memberful_admin_feeds_url( $format = MEMBERFUL_JSON ) {
-  return memberful_url( 'admin/feeds', $format );
 }
 
 function memberful_admin_subscription_plans_url( $format = MEMBERFUL_HTML ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -40,6 +40,10 @@ function memberful_admin_downloads_url( $format = MEMBERFUL_HTML ) {
   return memberful_url( 'admin/products', $format );
 }
 
+function memberful_admin_podcasts_url( $format = MEMBERFUL_JSON ) {
+  return memberful_url( 'admin/feeds', $format );
+}
+
 function memberful_admin_subscription_plans_url( $format = MEMBERFUL_HTML ) {
   return memberful_url( 'admin/subscriptions', $format );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/feeds.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/feeds.php
@@ -1,10 +1,10 @@
 <?php
 require_once MEMBERFUL_DIR.'/src/user/entity.php';
 
-class Memberful_Wp_User_Podcasts extends Memberful_Wp_User_Entity { 
+class Memberful_Wp_User_Feeds extends Memberful_Wp_User_Entity { 
 
   static public function sync( $user_id, $entities ) {
-    $syncer = new Memberful_Wp_User_Podcasts($user_id);
+    $syncer = new Memberful_Wp_User_Feeds($user_id);
     return $syncer->set($entities);
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/podcasts.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/podcasts.php
@@ -1,0 +1,21 @@
+<?php
+require_once MEMBERFUL_DIR.'/src/user/entity.php';
+
+class Memberful_Wp_User_Podcasts extends Memberful_Wp_User_Entity { 
+
+  static public function sync( $user_id, $entities ) {
+    $syncer = new Memberful_Wp_User_Podcasts($user_id);
+    return $syncer->set($entities);
+  }
+
+  protected function entity_type() {
+    return 'feed';
+  }
+
+  protected function format( $entity ) {
+    return array(
+      'id'              => $entity->feed->id,
+      'url'             => $entity->url
+    );
+  }
+}

--- a/wordpress/wp-content/plugins/memberful-wp/views/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/options.php
@@ -4,7 +4,7 @@
   <div id="memberful-wrap">
     <div id="memberful-registered" class="postbox">
       <h1><?php _e( 'Integration Active', 'memberful' ); ?></h1>
-      <h2><?php printf( __( 'Syncing %d plans and %d downloads.', 'memberful' ), count( $subscriptions ), count( $products ) ); ?></h2>
+      <h2><?php printf( __( 'Syncing %d plans, %d downloads and %d podcasts.', 'memberful' ), count( $subscriptions ), count( $products ), count( $feeds ) ); ?></h2>
       <p><?php printf( __( '<a href="%s">Sign in to your Memberful account</a> to manage products, subscriptions, members, and orders.' ), memberful_url( 'admin' ) ) ?></p>
       <form method="POST" action="<?php echo memberful_wp_plugin_settings_url(TRUE) ?>">
         <?php memberful_wp_nonce_field( 'memberful_options' ); ?>


### PR DESCRIPTION
* 47473d2 **Sync Podcasts with MemberAccount**
  
  The main app now returns the member's feeds in the MemberAccount
  payload. We'll map it to a new column in the user's table.
  
  This will be used later to display the tokenized URL for a given Podcast

* 129934c **Add function to check if user has podcast(s)**
  
  This allows the admin to check if the current user has access to the
  given podcast (or podcasts, if an array is given).

* 13095fc **Sync Podcasts with the app**
  
  The plugin will now listen to podcast Webhooks sent from the main app.
  It will then fetch all the Podcasts from the API and persist them in the
  database.
  
  We'll also sync the Podcasts during plugin activation and
  manual-sync.

* 36138cc **Add a shortcode to return the podcast URL**
  
  This shortcode will return the tokenized feed URL for the current user.
  If the user doesn't have access to the podcast, the shortcode doesn't
  return anything.

