### PR TITLE
Recover more reliably from duplicate mapping errors

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -25,6 +25,21 @@ function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context =
  * @return WP_User
  */
 function memberful_wp_sync_member_account( $account, $mapping_context ) {
+  $user = memberful_wp_sync_user( $account, $mapping_context );
+
+  if ( is_wp_error( $user ) ) {
+    memberful_wp_record_wp_error( $user );
+
+    if ( $user->get_error_code() === "duplicate_user_for_member" ) {
+      $user = memberful_wp_sync_user( $account, $mapping_context );
+      return $user;
+    }
+  }
+
+  return $user;
+}
+
+function memberful_wp_sync_user( $account, $mapping_context ) {
   global $wpdb;
   $mapper = new Memberful_User_Map();
 
@@ -52,11 +67,12 @@ function memberful_wp_sync_member_account( $account, $mapping_context ) {
     $wpdb->query( "COMMIT" );
   } else {
     $wpdb->query( "ROLLBACK" );
-    memberful_wp_record_error(array(
-      'error' => $user->get_error_messages(),
-      'code'  => $user->get_error_code(),
-      'member_email' => $account->member->email
-    ));
+
+    // Prevent WP from caching a user created by the failed transaction
+    $error_data = $user->get_error_data();
+    if ( $error_data['wp_user'] ) {
+      clean_user_cache( $error_data['wp_user'] );
+    }
   }
 
   return $user;

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -100,25 +100,13 @@ class Memberful_User_Map {
       $method = 'create_mapping';
     }
 
-    $outcome_of_mapping = $this->repository()->$method( $wp_user, $member, $context );
+    $result = $this->repository()->$method( $wp_user, $member, $context );
 
-    if ( is_wp_error( $outcome_of_mapping ) ) {
-      if ( $outcome_of_mapping->get_error_code() === "duplicate_user_for_member" && ! $wp_user_existed_before_request ) {
-        // We only record this error as others will be passed up and recorded
-        // by something else, whereas here we're working around the error.
-        memberful_wp_record_wp_error( $outcome_of_mapping );
-
-        wp_delete_user( $wp_user->ID );
-
-        $error_data = $outcome_of_mapping->get_error_data();
-
-        return $error_data['canonical_user'];
-      } else {
-        return $outcome_of_mapping;
-      }
+    if ( is_wp_error( $result ) ) {
+      return $result;
+    } else {
+      return $wp_user;
     }
-
-    return $wp_user;
   }
 
   private function add_data_to_wp_error( WP_Error $error, array $data ) {
@@ -139,7 +127,7 @@ class Memberful_User_Map {
 
 }
 
-class Memberful_User_Mapping_Ensure_User { 
+class Memberful_User_Mapping_Ensure_User {
 
   private $wp_user;
   private $member;
@@ -151,7 +139,7 @@ class Memberful_User_Mapping_Ensure_User {
   }
 
   public function ensure_present() {
-    $user_id = $this->user_exists ? $this->update_user() : $this->create_user(); 
+    $user_id = $this->user_exists ? $this->update_user() : $this->create_user();
 
     if ( is_wp_error( $user_id ) ) {
       $user_id->add_data( array_merge( (array) $user_id->get_error_data(), compact('user_data') ) );
@@ -390,16 +378,13 @@ class Memberful_User_Mapping_Repository {
     if ( $result === FALSE ) {
       // Race condition, some other process has reserved the mapping
       if ( strpos( strtolower( $wpdb->last_error ), 'duplicate entry' ) !== FALSE ) {
-        $real_mapping = $this->find_user_member_is_mapped_to( $member );
-
         return new WP_Error(
           "duplicate_user_for_member",
           "Some other process created the user and mapping before we could. Use the earlier version",
           array(
-            'canonical_user' => $real_mapping['user'],
-            'member'         => $member,
-            'context'        => $context,
-            'our_user'       => $wp_user,
+            'context' => $context,
+            'member'  => $member,
+            'wp_user' => $wp_user
           )
         );
       } else {


### PR DESCRIPTION
When two requests attempt to sync the same new user at the same time,
the second typically encounters a "duplicate_user_for_member" error
propagated from the primary key constraint on the mapping table.

The previous handling attempted to recover by loading the user
inserted by the first transaction, but within the second transaction
that generally didn't work; it's likely that the repeatable read
isolation level prevented it.

This change switches to a rollback-and-retry approach. There are still
conceivable ways for the retry to fail (esp. if the first transaction
is still incomplete), but they're not very likely, so this seems like
an acceptable approach for now.