### PR TITLE
Add price to the memberful_buy_subscription_link shortcode

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
@@ -96,7 +96,7 @@
         name: "price",
         type: "textbox",
         label: "Price (optional)",
-        tooltip: "Works only with plans where members are allowed to set price."
+        tooltip: "Works only with plans where members can choose what they pay."
       };
 
       body.push(priceCtrl);

--- a/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/memberful-wp-tinymce-plugin.js
@@ -72,43 +72,53 @@
   }
 
   function insertCheckoutLinkDialog(editor, options) {
-    var checkoutItemCtrl = {}, linkTextCtrl = {};
-
     function optionsForPurchasables(current) {
       return {text: current.name, value: current.slug};
     };
 
-    options = options || {};
-
-    checkoutItemCtrl = {
+    var checkoutItemCtrl = {
       name: "item",
       type: "listbox",
       label: options.label,
       values: options.choices.map(optionsForPurchasables)
     };
 
-    linkTextCtrl = {
+    var linkTextCtrl = {
       name: "linkText",
       type: "textbox",
       label: "Link text"
     };
 
+    var body = [checkoutItemCtrl, linkTextCtrl];
+
+    if(options.showPrice) {
+      var priceCtrl = {
+        name: "price",
+        type: "textbox",
+        label: "Price (optional)",
+        tooltip: "Works only with plans where members are allowed to set price."
+      };
+
+      body.push(priceCtrl);
+    }
+
     editor.windowManager.open({
       title: options.dialogTitle || "Link to checkout",
-      body: [
-        checkoutItemCtrl,
-        linkTextCtrl
-      ],
+      body: body,
       onSubmit: function(e) {
-        (options.onSubmit || function() {})(editor, e.data.item, e.data.linkText);
+        (options.onSubmit || function() {})(editor, e.data.item, e.data.linkText, e.data.price);
       }
     });
 
   }
 
   function insertSubscriptionCheckoutLink(editor) {
-    handleDialogSubmit = function(editor, plan, linkText) {
-      var shortcode = "[memberful_buy_subscription_link plan='" + plan + "']" + linkText + "[/memberful_buy_subscription_link]";
+    handleDialogSubmit = function(editor, plan, linkText, price = null) {
+      let shortcode = `[memberful_buy_subscription_link plan=${plan}`;
+      if(price) {
+        shortcode += ` price=${price}`
+      }
+      shortcode += `]${linkText}[/memberful_buy_subscription_link]`;
 
       editor.insertContent(shortcode);
     };
@@ -118,7 +128,8 @@
       {
         label: "Plan to subscribe to",
         choices: window.MemberfulData.plans,
-        onSubmit: handleDialogSubmit
+        onSubmit: handleDialogSubmit,
+        showPrice: true
       }
     );
   };

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= not released =
+
+* Add possibility to set price in "Choose what you pay" checkout links.
+
 = 1.54.1 =
 
 * Fix a bug affecting login after checkout.

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -21,9 +21,12 @@ function memberful_wp_shortcode_buy_download_link( $atts, $content ) {
 }
 
 function memberful_wp_shortcode_buy_subscription_link( $atts, $content ) {
-  $url = memberful_checkout_for_subscription_url(
-    memberful_wp_extract_id_from_slug( $atts['plan'] )
-  );
+  $plan_id = memberful_wp_extract_id_from_slug( $atts['plan'] );
+  $url = add_query_arg( 'plan', $plan_id, memberful_url( 'checkout' ) );
+
+  if( isset( $atts['price'] ) ) {
+    $url = add_query_arg( 'price', $atts['price'], $url );
+  }
 
   return '<a href="'.$url.'">'.do_shortcode($content).'</a>';
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -60,10 +60,6 @@ function memberful_order_completed_url( $order ) {
   return add_query_arg( 'id', $order, memberful_url( 'orders/completed' ) );
 }
 
-function memberful_checkout_for_subscription_url( $plan_id ) {
-  return add_query_arg( 'plan', $plan_id, memberful_url( 'checkout' ) );
-}
-
 function memberful_gift_url( $plan_id ) {
   return add_query_arg( 'plan', $plan_id, memberful_url( 'gift' ) );
 }


### PR DESCRIPTION
This includes the "Link to checkout" TinyMCE dialog for creating
shortcodes. The price field is shown for all plans at the moment. It
looks that it is possible to show it only for "Choose what you pay"
plans, however this change looks order of magnitude more complex and it
might not be worth doing it.

<img width="389" alt="Screenshot 2020-07-01 at 10 38 48" src="https://user-images.githubusercontent.com/522375/86240280-34e87600-bba1-11ea-9ee0-2cd8b8d635ca.png">

The tooltip is shown only on hover.

https://3.basecamp.com/3293071/buckets/17429243/todolists/2740201364