### PR TITLE
Fix bulk restrict category select

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/admin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/admin.js
@@ -21,7 +21,7 @@ jQuery(document).ready(function($){
 
     var callback = function() {
       var self = $(this);
-      var field_value = self.attr('value');
+      var field_value = self.val();
       var dependent_can_be_shown = false;
       var fieldType = self.prop('tagName') == 'SELECT' ? 'select' : self.prop('type');
       var checked = self.is(':checked');


### PR DESCRIPTION
The JS to dynamically display form elements based on other input values
was not switching based on the element's property value, but was using
the element's attribute value set on page creation.

This would mean that when a select field was used as the dynamic element
for "data-depends-on" it would always return the value it was originally
set to for comparison, and not whatever it was updated to.

https://3.basecamp.com/3293071/buckets/5610905/todos/2960092719