### PR TITLE
Abbreviate as an ellipsis

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -1,6 +1,10 @@
 #memberful-wrap {
   max-width: 360px;
 }
+.mce-listbox button {
+  text-overflow: ellipsis!important;
+  overflow: hidden!important;
+}
 
 /*---------------------------------------------------------
 Sign up for Memberful or Register


### PR DESCRIPTION
This fixes a small display issue, where the selected item in an MCE dialog could break out of its container.

<img width="441" alt="Screen Shot 2020-08-25 at 3 02 49 PM" src="https://user-images.githubusercontent.com/366462/91235072-916f9980-e6e9-11ea-8cfb-83510d4041d7.png">
