### PR TITLE
Add shortcode that checks for any active subscription

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
@@ -50,6 +50,17 @@ function memberful_wp_user_has_subscriptions( $user_id, array $subscriptions ) {
 }
 
 /**
+ * Check if the given user has an active subscription to any plan
+ *
+ * @param int          $user_id ID of the user who should have the subscription
+ * @return bool
+ */
+function is_subscribed_to_any_memberful_plan( $user_id ) {
+  $plans = memberful_wp_user_plans_subscribed_to( $user_id );
+  return !empty( $plans );
+}
+
+/**
  * Check that the current member has a subscription to at least least one of the required plans
  *
  * @param string|array $slug    Slug of the plan the user should have. Can pass an array of slugs

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -11,6 +11,7 @@ add_shortcode( 'memberful_sign_in_link',  'memberful_wp_shortcode_sign_in_link' 
 add_shortcode( 'memberful_sign_out_link', 'memberful_wp_shortcode_sign_out_link' );
 add_shortcode( 'memberful_podcasts_link',  'memberful_wp_shortcode_feeds_link' );
 add_shortcode( 'memberful_podcast_url', 'memberful_wp_shortcode_feed_url' );
+add_shortcode( 'memberful_if_has_active_subscription', 'memberful_wp_shortcode_if_has_active_subscription' );
 
 function memberful_wp_shortcode_buy_download_link( $atts, $content ) {
   $url = memberful_checkout_for_download_url(
@@ -154,6 +155,16 @@ function memberful_wp_shortcode_private_user_feed_link($atts = array(), $content
   $category = $atts['category'] ?? '';
 
   return memberful_private_rss_feed_link($content, __("You don’t have access to this RSS feed."), true, $category);
+}
+
+function memberful_wp_shortcode_if_has_active_subscription( $atts, $content ) {
+  $user_id = wp_get_current_user()->ID;
+
+  if ( is_subscribed_to_any_memberful_plan( $user_id ) ) {
+    return do_shortcode($content);
+  } else {
+    return '';
+  }
 }
 
 function memberful_wp_slugs_to_ids( $slugs ) {


### PR DESCRIPTION
* 821b9e8 **Add helper to check for any active subscription**

* 0d39c2a **Add shortcode to check for any active subscription**
  
  With this shortcode, admins can choose to show content only for members
  with an active subscription.
  
  This is useful when you have a page/post that is shown to everyone, but
  you want to restrict individual sections to members only.
  
  https://3.basecamp.com/3293071/buckets/9856127/todos/3070993726

