### PR TITLE
Add shortcode to check for lack of active subscription

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -12,6 +12,7 @@ add_shortcode( 'memberful_sign_out_link', 'memberful_wp_shortcode_sign_out_link'
 add_shortcode( 'memberful_podcasts_link',  'memberful_wp_shortcode_feeds_link' );
 add_shortcode( 'memberful_podcast_url', 'memberful_wp_shortcode_feed_url' );
 add_shortcode( 'memberful_if_has_active_subscription', 'memberful_wp_shortcode_if_has_active_subscription' );
+add_shortcode( 'memberful_if_does_not_have_active_subscription', 'memberful_wp_shortcode_if_does_not_have_active_subscription' );
 
 function memberful_wp_shortcode_buy_download_link( $atts, $content ) {
   $url = memberful_checkout_for_download_url(
@@ -164,6 +165,16 @@ function memberful_wp_shortcode_if_has_active_subscription( $atts, $content ) {
     return do_shortcode($content);
   } else {
     return '';
+  }
+}
+
+function memberful_wp_shortcode_if_does_not_have_active_subscription( $atts, $content ) {
+  $user_id = wp_get_current_user()->ID;
+
+  if ( is_subscribed_to_any_memberful_plan( $user_id ) ) {
+    return '';
+  } else {
+    return do_shortcode($content);
   }
 }
 


### PR DESCRIPTION
With this shortcode, admins can choose to show content only for members
without an active subscription.

This is useful when you have a page/post that is shown to everyone, but
you want to restrict individual sections to inactive members only.