### PR TITLE
Add support for SG Optimizer frontend optimization

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -52,6 +52,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 = unreleased =
 
 * Add custom post types support to Bulk restrict access tool.
+* Add support for SG Optimizer frontend optimization
 
 = 1.59.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/embed.js.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/embed.js.php
@@ -15,7 +15,7 @@
     s.async = true;
     s.src = '<?php echo $script_src; ?>';
 
-    setup = function() { window.MemberfulEmbedded.setup(); }
+    setup = function() { window.MemberfulEmbedded.setup(); };
 
     s.addEventListener("load", setup, false);
 


### PR DESCRIPTION
SiteGround has its own WordPress plugin for site optimization. One of
the things it does is that it optimizes (minifies) the frontend code.
However, this feature breaks our embed code.

This commit fixes it by adding a semicolon to the embed code. This fix 
has been successfully tested on a production site.

---

The overlay breaks when the following option is enabled:

![image](https://user-images.githubusercontent.com/522375/101464364-d2a95380-393e-11eb-9837-7c2337bccd7a.png)

Missing semicolon in the optimized code:

![image](https://user-images.githubusercontent.com/522375/101464480-fcfb1100-393e-11eb-8543-3a5bb29e729a.png)

![image](https://user-images.githubusercontent.com/522375/101464617-274cce80-393f-11eb-9d26-795b70f5fb1c.png)
