### PR TITLE
Make private user feed title configurable

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Allow filtering of private feed title
+
 = 1.60.0 =
 
 * Add custom post types support to Bulk restrict access tool.

--- a/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
@@ -165,3 +165,16 @@ if(!function_exists('memberful_private_user_feed_get_url_identifier'))  {
   }
 
 }
+function memberful_private_user_feed_description() {
+  $description = memberful_get_bloginfo_rss( 'description' );
+  return apply_filters( 'memberful_private_rss_description', $description );
+}
+
+function memberful_private_user_feed_title() {
+  $title = memberful_get_bloginfo_rss( 'name' ) . ' Member Feed';
+  return apply_filters( 'memberful_private_rss_title', $title );
+}
+
+function memberful_get_bloginfo_rss( $attribute ) {
+  return apply_filters( 'bloginfo_rss', get_bloginfo_rss( $attribute ), $attribute );
+}

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
@@ -36,15 +36,10 @@ do_action( 'rss_tag_pre', 'rss2' );
     <?php endif; ?>
     <?php do_action('rss2_ns'); ?>>
   <channel>
-    <title><?php bloginfo_rss('name'); ?> Member Feed</title>
+    <title><?php echo memberful_private_user_feed_title(); ?></title>
     <atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
     <link><?php bloginfo_rss('url') ?></link>
-    <description>
-      <?php
-        $default_description = apply_filters( 'bloginfo_rss', get_bloginfo_rss( 'description' ), 'description' );
-        echo apply_filters( 'memberful_private_rss_description', $default_description )
-      ?>
-    </description>
+    <description><?php echo memberful_private_user_feed_description(); ?></description>
     <lastBuildDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_lastpostmodified('GMT'), false); ?></lastBuildDate>
     <language><?php bloginfo_rss( 'language' ); ?></language>
     <?php if (get_option('memberful_add_block_tags_to_rss_feed')): ?>


### PR DESCRIPTION
This is a continuation of #264. I've introduced a new helper function
`memberful_get_bloginfo_rss()` which makes getting `bloginfo_rss`
attributes easier.

https://3.basecamp.com/3293071/buckets/9856127/messages/3301743790