### PR TITLE
Add option to block Wordpress dashboard

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -59,6 +59,7 @@ require_once MEMBERFUL_DIR . '/src/comments_protection.php';
 require_once MEMBERFUL_DIR . '/src/nav_menus.php';
 require_once MEMBERFUL_DIR . '/src/bulk_protect.php';
 require_once MEMBERFUL_DIR . '/src/hide_admin_toolbar.php';
+require_once MEMBERFUL_DIR . '/src/block_dashboard_access.php';
 
 if ( in_array( 'sensei/woothemes-sensei.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
   require_once MEMBERFUL_DIR . '/src/contrib/woothemes-sensei.php';

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -52,6 +52,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 = Unreleased =
 
 * Add option to hide admin toolbar from members 
+* Add option to block Wordpress dashboard from members
 
 = 1.61.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -249,6 +249,7 @@ function memberful_wp_options() {
     if ( isset( $_POST['save_changes'] ) ) {
       update_option( 'memberful_extend_auth_cookie_expiration', isset( $_POST['extend_auth_cookie_expiration'] ));
       update_option( 'memberful_hide_admin_toolbar', isset( $_POST['memberful_hide_admin_toolbar'] ));
+      update_option( 'memberful_block_dashboard_access', isset( $_POST['memberful_block_dashboard_access'] ));
 
       return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
     }
@@ -280,6 +281,7 @@ function memberful_wp_options() {
   $feeds = get_option( 'memberful_feeds', array() );
   $extend_auth_cookie_expiration = get_option( 'memberful_extend_auth_cookie_expiration' );
   $hide_admin_toolbar = get_option( 'memberful_hide_admin_toolbar' );
+  $block_dashboard_access = get_option( 'memberful_block_dashboard_access' );
 
   memberful_wp_render (
     'options',
@@ -288,7 +290,8 @@ function memberful_wp_options() {
       'feeds' => $feeds,
       'subscriptions' => $subscriptions,
       'extend_auth_cookie_expiration' => $extend_auth_cookie_expiration,
-      'hide_admin_toolbar' => $hide_admin_toolbar
+      'hide_admin_toolbar' => $hide_admin_toolbar,
+      'block_dashboard_access' => $block_dashboard_access
     )
   );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/block_dashboard_access.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/block_dashboard_access.php
@@ -1,0 +1,9 @@
+<?php
+function redirect_members_home() {
+  if ( get_option( 'memberful_block_dashboard_access' ) && !current_user_can( 'edit_posts' )) {
+    wp_redirect( home_url() );
+    exit();
+  }
+}
+
+add_action( 'admin_init', 'redirect_members_home' );

--- a/wordpress/wp-content/plugins/memberful-wp/src/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/options.php
@@ -17,6 +17,7 @@ function memberful_wp_all_options() {
     'memberful_role_inactive_customer' => 'subscriber',
     'memberful_posts_available_to_any_registered_user' => array(),
     'memberful_hide_admin_toolbar' => TRUE,
+    'memberful_block_dashboard_access' => TRUE,
     MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT => NULL
   );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/views/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/options.php
@@ -34,6 +34,12 @@
               <span class="memberful-label__text--multiline">Hide the WordPress admin toolbar from members.</span>
           </label>
         </p>
+        <p>
+          <label for="block_dashboard_access_checkbox">
+            <input id="block_dashboard_access_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_block_dashboard_access" <?php if( $block_dashboard_access): ?>checked="checked"<?php endif; ?>>
+              <span class="memberful-label__text--multiline">Block Wordpress dashboard access from members.</span>
+          </label>
+        </p>
         <button type="submit" name="save_changes" class="button button-primary">Save Changes</button>
       </form>
     </div>


### PR DESCRIPTION
When enabled this will block any member attempt to view a Wordpress
admin page like the profile dashboard.

It does not block access for site admins or any member with post editing
permissions.

The feature is enabled by default.