### PR TITLE
Filter account menu items based on signed-in state

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -60,6 +60,7 @@ require_once MEMBERFUL_DIR . '/src/nav_menus.php';
 require_once MEMBERFUL_DIR . '/src/bulk_protect.php';
 require_once MEMBERFUL_DIR . '/src/hide_admin_toolbar.php';
 require_once MEMBERFUL_DIR . '/src/block_dashboard_access.php';
+require_once MEMBERFUL_DIR . '/src/filter_account_menu_items.php';
 
 if ( in_array( 'sensei/woothemes-sensei.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
   require_once MEMBERFUL_DIR . '/src/contrib/woothemes-sensei.php';

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -54,6 +54,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 * Fix "Link to download" select box
 * Add option to hide admin toolbar from members 
 * Add option to block Wordpress dashboard from members
+* Add option to filter account links in menus based on signed-in state
 
 = 1.61.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -250,6 +250,7 @@ function memberful_wp_options() {
       update_option( 'memberful_extend_auth_cookie_expiration', isset( $_POST['extend_auth_cookie_expiration'] ));
       update_option( 'memberful_hide_admin_toolbar', isset( $_POST['memberful_hide_admin_toolbar'] ));
       update_option( 'memberful_block_dashboard_access', isset( $_POST['memberful_block_dashboard_access'] ));
+      update_option( 'memberful_filter_account_menu_items', isset( $_POST['memberful_filter_account_menu_items'] ));
 
       return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
     }
@@ -282,6 +283,7 @@ function memberful_wp_options() {
   $extend_auth_cookie_expiration = get_option( 'memberful_extend_auth_cookie_expiration' );
   $hide_admin_toolbar = get_option( 'memberful_hide_admin_toolbar' );
   $block_dashboard_access = get_option( 'memberful_block_dashboard_access' );
+  $filter_account_menu_items= get_option( 'memberful_filter_account_menu_items' );
 
   memberful_wp_render (
     'options',
@@ -291,7 +293,8 @@ function memberful_wp_options() {
       'subscriptions' => $subscriptions,
       'extend_auth_cookie_expiration' => $extend_auth_cookie_expiration,
       'hide_admin_toolbar' => $hide_admin_toolbar,
-      'block_dashboard_access' => $block_dashboard_access
+      'block_dashboard_access' => $block_dashboard_access,
+      'filter_account_menu_items' => $filter_account_menu_items
     )
   );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/filter_account_menu_items.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/filter_account_menu_items.php
@@ -1,0 +1,20 @@
+<?php
+function filter_account_links( $items ) {
+  foreach ( $items as $key => $item ) {
+    if ( is_user_logged_in() ) {
+      if ( $item->url == memberful_sign_in_url()) {
+        unset( $items[$key] );
+      }
+    } else {
+      if ( in_array($item->url, [ memberful_sign_out_url(), memberful_account_url() ])) {
+        unset( $items[$key] );
+      }
+    }
+  }
+
+  return $items;
+}
+
+if ( get_option( 'memberful_filter_account_menu_items' )) {
+  add_filter( 'wp_get_nav_menu_items', 'filter_account_links' );
+}

--- a/wordpress/wp-content/plugins/memberful-wp/src/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/options.php
@@ -18,6 +18,7 @@ function memberful_wp_all_options() {
     'memberful_posts_available_to_any_registered_user' => array(),
     'memberful_hide_admin_toolbar' => TRUE,
     'memberful_block_dashboard_access' => TRUE,
+    'memberful_filter_account_menu_items' => TRUE,
     MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT => NULL
   );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/views/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/options.php
@@ -40,6 +40,12 @@
               <span class="memberful-label__text--multiline">Block Wordpress dashboard access from members.</span>
           </label>
         </p>
+        <p>
+          <label for="filter_account_menu_items_checkbox">
+            <input id="filter_account_menu_items_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_filter_account_menu_items" <?php if( $filter_account_menu_items): ?>checked="checked"<?php endif; ?>>
+              <span class="memberful-label__text--multiline">Conditionally show "Sign in," "Sign out," and "Account" menu items based on members' signed-in status.</span>
+          </label>
+        </p>
         <button type="submit" name="save_changes" class="button button-primary">Save Changes</button>
       </form>
     </div>


### PR DESCRIPTION
Adding an option (on by default) to filter out "Sign in" links from
menus when already signed in, and filter out "Sign out" links when
signed out.