### PR TITLE
Add content access by term (category or tag)

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/term_options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/term_options.php
@@ -1,0 +1,45 @@
+<?php
+
+function memberful_wp_get_term_available_to_any_registered_users( $term_id ) {
+  return get_term_meta( $term_id, 'memberful_available_to_any_registered_user', TRUE ) === "1";
+}
+
+function memberful_wp_set_term_available_to_any_registered_users( $term_id, $is_viewable_by_any_registered_users ) {
+  update_term_meta( $term_id, 'memberful_available_to_any_registered_user', $is_viewable_by_any_registered_users);
+
+  $globally_viewable_by_any_registered_users = memberful_wp_get_all_terms_available_to_any_registered_user();
+
+  if ( $is_viewable_by_any_registered_users ) {
+    $globally_viewable_by_any_registered_users[$term_id] = $term_id;
+  } else {
+    unset($globally_viewable_by_any_registered_users[$term_id]);
+  }
+
+  update_option( 'memberful_terms_available_to_any_registered_user', $globally_viewable_by_any_registered_users );
+}
+
+function memberful_wp_get_all_terms_available_to_any_registered_user() {
+  return get_option( 'memberful_terms_available_to_any_registered_user', array() );
+}
+
+function memberful_wp_get_term_available_to_anybody_subscribed_to_a_plan( $term_id ) {
+  return get_term_meta( $term_id, 'memberful_available_to_anybody_subscribed_to_a_plan', TRUE ) === "1";
+}
+
+function memberful_wp_set_term_available_to_anybody_subscribed_to_a_plan( $term_id, $is_viewable ) {
+  update_term_meta( $term_id, 'memberful_available_to_anybody_subscribed_to_a_plan', $is_viewable );
+
+  $terms_available_to_anybody_subscribed_to_a_plan = memberful_wp_get_all_terms_available_to_anybody_subscribed_to_a_plan();
+
+  if ( $is_viewable ) {
+    $terms_available_to_anybody_subscribed_to_a_plan[$term_id] = $term_id;
+  } else {
+    unset($terms_available_to_anybody_subscribed_to_a_plan[$term_id]);
+  }
+
+  update_option( 'memberful_terms_available_to_anybody_subscribed_to_a_plan', $terms_available_to_anybody_subscribed_to_a_plan);
+}
+
+function memberful_wp_get_all_terms_available_to_anybody_subscribed_to_a_plan() {
+  return get_option( 'memberful_terms_available_to_anybody_subscribed_to_a_plan', array() );
+}

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -4,12 +4,29 @@ define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
 define( 'MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
 
 function memberful_marketing_content( $post_id ) {
-  $memberful_marketing_content = get_post_meta( $post_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
-  return apply_filters( 'memberful_marketing_content', $memberful_marketing_content );
+  $user_id = is_user_logged_in() ? get_current_user_id() : 0;
+  $restricted_posts = memberful_wp_user_disallowed_post_ids( $user_id );
+
+  if ( isset( $restricted_posts[$post_id] )) {
+    $memberful_marketing_content = get_post_meta( $post_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
+    return apply_filters( 'memberful_marketing_content', $memberful_marketing_content );
+  } else {
+    $terms = memberful_terms_restricting_post( $user_id, $post_id );
+    return memberful_term_marketing_content( reset( $terms ));
+  }
+}
+
+function memberful_term_marketing_content( $term_id ) {
+  $term_marketing_content = get_term_meta( $term_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
+  return apply_filters( 'memberful_marketing_content', $term_marketing_content );
 }
 
 function memberful_wp_update_post_marketing_content( $post_id, $content ) {
   update_post_meta( $post_id, MEMBERFUL_MARKETING_META_KEY, $content );
+}
+
+function memberful_wp_update_term_marketing_content( $term_id, $content ) {
+  update_term_meta( $term_id, MEMBERFUL_MARKETING_META_KEY, $content );
 }
 
 function memberful_wp_update_default_marketing_content( $content ) {

--- a/wordpress/wp-content/plugins/memberful-wp/views/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/metabox.php
@@ -15,7 +15,7 @@
       <div class="memberful-marketing-content-description">
         <label>
           <input type="checkbox" name="memberful_make_default_marketing_content" value="1">
-          Make this the default marketing content for new posts and pages
+          Make this the default marketing content for new posts, pages, tags and categories.
         </label>
       </div>
     </div>


### PR DESCRIPTION
Restricting access to posts automatically by category or tag. With
related marketing content set at the term level.

Post restrictions take precedence, if any terms with restrictions are
added to a restricted post the post-specific restrictions will be used
and term restrictions ignored.