### PR TITLE
Allow ajax admin access when dashboard blocked

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= Unreleased =
+
+* Fix conflicts with plugins that require Ajax-based admin access when using the new "Block dashboard for members" feature. These include stats tracking plugins like Statify, as well as Wordfence Login Security.
+
 = 1.62.0 =
 
 * Fix "Link to download" select box

--- a/wordpress/wp-content/plugins/memberful-wp/src/block_dashboard_access.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/block_dashboard_access.php
@@ -1,5 +1,8 @@
 <?php
 function redirect_members_home() {
+  if ( defined( 'DOING_AJAX' ))
+    return;
+
   if ( get_option( 'memberful_block_dashboard_access' ) && !current_user_can( 'edit_posts' )) {
     wp_redirect( home_url() );
     exit();


### PR DESCRIPTION
This prevents conflicts with plugins that use the Wordpress ajax admin
endpoint, but still allows us to redirect members from visiting the
Wordpress dashboard with the new option enabled.