### PR TITLE
Fix "Sign in" items in admin menu editor

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= Unreleased =
+
+* Fix display of "Sign in" items in admin menu editor
+
 = 1.62.2 =
 
 * Improve unescaping of redirect_to param

--- a/wordpress/wp-content/plugins/memberful-wp/src/filter_account_menu_items.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/filter_account_menu_items.php
@@ -15,6 +15,6 @@ function filter_account_links( $items ) {
   return $items;
 }
 
-if ( get_option( 'memberful_filter_account_menu_items' )) {
+if ( get_option( 'memberful_filter_account_menu_items' ) && !is_admin() ) {
   add_filter( 'wp_get_nav_menu_items', 'filter_account_links' );
 }


### PR DESCRIPTION
These items were being hidden by our account menu item filter, as it was
overzealously removing all sign in links when enabled, even in the admin
menu editor.

This fix checks the request is not for an admin page before applying the
filter.