### PR TITLE
Update filter priority

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'the_content', 'memberful_wp_protect_content', -10 );
+add_action( 'the_content', 'memberful_wp_protect_content', 100 );
 
 function memberful_wp_protect_content( $content ) {
   global $post;
@@ -27,3 +27,5 @@ function memberful_wp_protect_content( $content ) {
 
   return $content;
 }
+
+add_filter( 'memberful_wp_protect_content', 'do_shortcode' );


### PR DESCRIPTION
Negative action priorities can often result in unexpected behavior on filtering.

In this case, the -10 priority filter on your 'memberful_wp_protect_content' function applied to the 'the_content' filter is overwritten by elementor reaccessing the post's data as part of the blogroll loop.

More common behavior for membership plugins is to hook into the content at a later entry priority (I used 100 here, which matches Restrict Content Pro), and then ensure key filters (such as 'do_shortcodes') are applied to the marketing content.