### PR TITLE
Use configurable member role on pass reset

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Use configured Memberful user role when checking password reset permission
+
 = 1.62.5 =
 
 * Fix Memberful connection issue

--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -19,8 +19,9 @@ class Memberful_Authenticator {
    */
   static public function audit_password_reset( $allowed, $user_id ) {
     $user = new WP_User( $user_id );
+    $member_role = memberful_wp_role_for_active_customer();
 
-    return $user->has_cap( 'subscriber' ) ? FALSE : $allowed;
+    return $user->has_cap( $member_role ) ? FALSE : $allowed;
   }
 
   /**


### PR DESCRIPTION
The plugin blocks use of the Wordpress password reset feature for
members, as this is something handled by Memberful directly.

We previously hard coded the "subscriber" role as being the one to block
when a password reset attempt is made via Wordpress, however we allow
the role given to Memberful members to be configurable, this change
ensures only the set role have access to password reset blocked.

https://github.com/memberful/memberful-wp/issues/279