### PR TITLE
Remove content filter on private member feed

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Fix content filter running on private member RSS feed
+
 = 1.62.5 =
 
 * Fix Memberful connection issue

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
@@ -28,7 +28,7 @@ class Memberful_Wp_Integration_WooCommerce {
   function remove_erroneous_protection( $content ) {
     global $post;
     if ($post->post_type == "product") {
-      remove_filter( 'the_content', 'memberful_wp_protect_content', -10 );
+      remove_filter( 'the_content', 'memberful_wp_protect_content', 100 );
     }
     return $content;
   }

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
@@ -7,7 +7,7 @@ remove_all_filters('the_excerpt');
 remove_all_filters('the_excerpt_rss');
 
 // For the content parse, we want to remove only the memberful part.
-remove_filter('the_content', 'memberful_wp_protect_content', -10);
+remove_filter('the_content', 'memberful_wp_protect_content', 100);
 
 $post_types = array("post");
 $category = $_GET['category'] ?? '';


### PR DESCRIPTION
Following our filter change to 100 priority we missed a couple of places
where we remove the filter. To successfully remove a filter the priority
has to match that when it was first set.