### PR TITLE
Enable compatibility with some Gutenberg Blocks

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -35,4 +35,5 @@ add_filter( 'memberful_wp_protect_content','wpautop');
 add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
+add_filter('memberful_wp_protect_content','do_blocks',1);
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );


### PR DESCRIPTION
Added do_blocks as an early filter to memberful_wp_protect content to enable compatibility with some Butenberg blocks, including gutenberg blocks created by Recipe Card Blocks by WPZOOM