### PR TITLE
Do not install "Verify domain for Apple Pay with Stripe"

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -54,7 +54,6 @@ db_pass: wordpress
 # Plugin's slug or url to the plugin's slug.
 #
 plugins:
-  - verify-domain-for-apple-pay-with-stripe
   - wordpress-beta-tester
 
 #


### PR DESCRIPTION
This plugin is obsolete and we do not need to install it anymore.