### PR TITLE
Remove obsolete provisioning task

### DIFF
--- a/provision-post.sh
+++ b/provision-post.sh
@@ -14,9 +14,3 @@ wp_create_page --post_title="Checkout page" --post_content="[memberful_buy_subsc
 wp_create_page --post_title="After sign in page"
 wp_create_page --post_title="After sign out page"
 wp widget add memberful_wp_profile_widget sidebar-1 1
-
-if ! grep "memberful.localhost" /etc/hosts; then
-  echo "Adding hosts entries for Memberful"
-  DEFAULT_GATEWAY=`ip route | grep default | awk '{print $3}'`
-  sudo sh -c "echo \"$DEFAULT_GATEWAY ttf.memberful.localhost apps.memberful.localhost\" >> /etc/hosts"
-fi


### PR DESCRIPTION
This task is not needed anymore because puma-dev takes care of
`.localhost` resolving. Also, the task is broken anyways because it
doesn't add any entries to `/etc/hosts`.