### PR TITLE
Do not create wordpress/.gitignore

### DIFF
--- a/provision/playbooks/wordpress.yml
+++ b/provision/playbooks/wordpress.yml
@@ -89,15 +89,6 @@
     when: vccw.wp_siteurl != ''
     command: "mv /tmp/index.php {{ vccw.document_root }}/index.php"
 
-  - name: Create `.gitignore`
-    get_url:
-      url: https://raw.githubusercontent.com/github/gitignore/master/WordPress.gitignore
-      dest: /tmp/.gitignore
-      mode: 0644
-      force: yes
-  - name: Move `.gitignore`
-    command: "mv /tmp/.gitignore {{ path }}/.gitignore"
-
   - name: Run `wp core language install`
     command: |
       wp core language install {{ vccw.lang }}


### PR DESCRIPTION
We already have a `.gitignore` file in the main directory and
`wordpress/.gitignore` clashes with it. As a result, some new files
added to `wordpress/wp-content/themes` are not ignored by Git. This is
pretty annoying because every time I run `vagrant up --provision`
`wordpress/wp-content/themes/index.php` gets added and Git lists it as
an untracked file.

After this is merged in, I suggest that you remove your local
`wordpress/.gitignore` file.