### PR TITLE
Set redirect_to param on OAuth requests

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -106,7 +106,6 @@ class Memberful_Authenticator {
       );
     }
 
-    // Store where the user came from in a cookie
     if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
       $redirect_to = $_SERVER['HTTP_REFERER'];
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -29,11 +29,15 @@ class Memberful_Authenticator {
    *
    * @return string
    */
-  static function oauth_auth_url() {
+  static function oauth_auth_url( $redirect_to ) {
     $params = array(
       'response_type' => 'code',
       'client_id'     => get_option( 'memberful_client_id' ),
     );
+
+    if ( $redirect_to ) {
+      $params['redirect_to'] = urlencode($redirect_to);
+    }
 
     return add_query_arg( $params, self::oauth_member_url() );
   }
@@ -104,21 +108,16 @@ class Memberful_Authenticator {
 
     // Store where the user came from in a cookie
     if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
-      $referer = $_SERVER['HTTP_REFERER'];
+      $redirect_to = $_SERVER['HTTP_REFERER'];
     }
 
     // Allow overriding of redirect location
     if ( isset( $_REQUEST['redirect_to'] ) ) {
-      $referer = $_REQUEST['redirect_to'];
-    }
-
-    if ( isset( $referer ) ) {
-      $expire  = time() + ( 30 * 60 ); // 30 minutes
-      setcookie( 'memberful_redirect', $referer, $expire, '/', COOKIE_DOMAIN, is_ssl(), true );
+      $redirect_to = $_REQUEST['redirect_to'];
     }
 
     // Send the user to Memberful
-    wp_redirect( self::oauth_auth_url(), 302 );
+    wp_redirect( self::oauth_auth_url( $redirect_to ), 302 );
     exit();
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/auth.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/auth.php
@@ -28,8 +28,6 @@ class Memberful_Wp_Endpoint_Auth implements Memberful_Wp_Endpoint {
       wp_signon( $credentials, is_ssl() );
 
       $redirect_to = $this->after_login_redirect_url( $request_params );
-
-      $this->clear_redirect_cookie();
     }
 
     wp_safe_redirect( $redirect_to );
@@ -45,26 +43,10 @@ class Memberful_Wp_Endpoint_Auth implements Memberful_Wp_Endpoint {
     if ( isset( $params['redirect_to'] ) ) {
       $url = $params['redirect_to'];
       $url = preg_match('/^https?%/', $url) ? urldecode($url) : $url;
-    } else if ( isset( $_COOKIE['memberful_redirect'] ) ) {
-      $url = $_COOKIE['memberful_redirect'];
     } else {
       $url = home_url();
     }
 
     return apply_filters( 'memberful_wp_after_sign_in_url', $url );
-  }
-
-  private function clear_redirect_cookie() {
-    if ( isset( $_COOKIE['memberful_redirect'] ) ) {
-      setcookie(
-        'memberful_redirect',
-        '',
-        time() - 3600,
-        COOKIEPATH,
-        COOKIE_DOMAIN,
-        is_ssl(),
-        true
-      );
-    }
   }
 }


### PR DESCRIPTION
This works around Chrome's SameSite cookie restriction when
?memberful_endpoint=auth links open in the overlay.