### PR TITLE
Return only first term restricting a post

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -284,16 +284,15 @@ function memberful_wp_post_viewable_by_any_subscriber( $post, $terms_for_post ) 
   return ( in_array( $post, $posts_for_anybody_subscribed_to_a_plan ) || array_intersect( $terms_for_post, $terms_for_anybody_subscribed_to_a_plan ));
 }
 
-function memberful_terms_restricting_post( $user, $post ) {
+function memberful_first_term_restricting_post( $user, $post ) {
   $restricted_terms = array_values( memberful_wp_user_disallowed_term_ids( $user ));
   $post_terms = memberful_wp_get_category_and_tag_ids_for_post( $post );
-  $restricting_terms_for_this_post = array();
 
   if ( !$user ) {
     $terms_requiring_any_user = array_intersect( $post_terms, memberful_wp_get_all_terms_available_to_any_registered_user() );
 
     if ( !empty( $terms_requiring_any_user )) {
-      array_push( $restricting_terms_for_this_post, ...$terms_requiring_any_user);
+      return reset ( $terms_requiring_any_user );
     }
   }
 
@@ -301,7 +300,7 @@ function memberful_terms_restricting_post( $user, $post ) {
     $terms_requiring_any_active_plan = array_intersect( $post_terms, memberful_wp_get_all_terms_available_to_anybody_subscribed_to_a_plan() );
 
     if ( !empty( $terms_requiring_any_active_plan )) {
-      array_push( $restricting_terms_for_this_post, ...$terms_requiring_any_active_plan);
+      return reset ( $terms_requiring_any_active_plan );
     }
   }
 
@@ -309,11 +308,9 @@ function memberful_terms_restricting_post( $user, $post ) {
     $terms_restricted_to_specific_plans = array_intersect( $restricted_terms, $post_terms );
 
     if ( !empty( $terms_restricted_to_specific_plans )) {
-      array_push ( $restricting_terms_for_this_post, ...$terms_restricted_to_specific_plans );
+      return reset( $terms_restricted_to_specific_plans );
     }
   }
-
-  return $restricting_terms_for_this_post;
 }
 
 function memberful_wp_get_category_and_tag_ids_for_post( $post ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -11,8 +11,8 @@ function memberful_marketing_content( $post_id ) {
   if ( isset( $restricted_posts[$post_id] )) {
     $marketing_content = memberful_post_marketing_content( $post_id );
   } else {
-    $terms = memberful_terms_restricting_post( $user_id, $post_id );
-    $marketing_content = memberful_term_marketing_content( reset( $terms ));
+    $term = memberful_first_term_restricting_post( $user_id, $post_id );
+    $marketing_content = memberful_term_marketing_content( $term );
   }
 
   return apply_filters( 'memberful_marketing_content', $marketing_content );


### PR DESCRIPTION
We do not need to build an array of all terms restricting a post because
we always use only the first term from this array. Therefore we can save
some work and return as soon as we find a term restricting a post.