### PR TITLE
Fix marketing content for the restrict content box

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -3,22 +3,27 @@
 define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
 define( 'MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
 
+// Get marketing content for the frontend
 function memberful_marketing_content( $post_id ) {
   $user_id = is_user_logged_in() ? get_current_user_id() : 0;
   $restricted_posts = memberful_wp_user_disallowed_post_ids( $user_id );
 
   if ( isset( $restricted_posts[$post_id] )) {
-    $memberful_marketing_content = get_post_meta( $post_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
-    return apply_filters( 'memberful_marketing_content', $memberful_marketing_content );
+    $marketing_content = memberful_post_marketing_content( $post_id );
   } else {
     $terms = memberful_terms_restricting_post( $user_id, $post_id );
-    return memberful_term_marketing_content( reset( $terms ));
+    $marketing_content = memberful_term_marketing_content( reset( $terms ));
   }
+
+  return apply_filters( 'memberful_marketing_content', $marketing_content );
+}
+
+function memberful_post_marketing_content( $post_id ) {
+  return get_post_meta( $post_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
 }
 
 function memberful_term_marketing_content( $term_id ) {
-  $term_marketing_content = get_term_meta( $term_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
-  return apply_filters( 'memberful_marketing_content', $term_marketing_content );
+  return get_term_meta( $term_id, MEMBERFUL_MARKETING_META_KEY, TRUE );
 }
 
 function memberful_wp_update_post_marketing_content( $post_id, $content ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -44,7 +44,7 @@ function memberful_wp_metabox( $post ) {
   }
 
   $marketing_content = array_filter(array(
-    memberful_marketing_content( $post->ID ),
+    memberful_post_marketing_content( $post->ID ),
     memberful_wp_default_marketing_content(),
     memberful_wp_marketing_content_explanation()
   ));


### PR DESCRIPTION
This commit includes two changes:

1. Do not use `memberful_marketing_content()` in `memberful_wp_metabox()`

`memberful_marketing_content()` should be used only for the frontend. It
is not suitable for use in `memberful_wp_metabox()` (e.g. in the admin
area) because its value depends on actual post restriction settings.

If a post currently doesn't have any restrictions, then we fallback to
default marketing content even if we saved marketing content for the
post before. This commit fixes it by using
`memberful_post_marketing_content()` which always returns post's saved
marketing content no matter current restriction settings. In fact, this
is what we alrady do in `memberful_wp_add_term_metabox()` for term
metaboxes.

2. Apply the `memberful_marketing_content` filter only in `memberful_marketing_content()`

I don't think that we should use this filter for metaboxes. Actually, we
currently do it in `main` because we use `memberful_marketing_content()`
for the metabox, but I don't think that this is a correct behaviour.