### PR TITLE
Non memberful user patch

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -129,7 +129,7 @@ function memberful_wp_user_feeds($user_id) {
  * @return array member's subscriptions
  */
 function memberful_wp_user_plans_subscribed_to( $user_id ) {
-  return get_user_meta( $user_id, 'memberful_subscription', TRUE );
+  return get_user_meta( $user_id, 'memberful_subscription', TRUE ) ?: array();
 }
 
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl/helpers.php
@@ -25,7 +25,7 @@ function has_memberful_product( $slug, $user_id = NULL ) {
  * @deprecated 1.6.0
  */
 function memberful_wp_user_products( $user_id ) {
-  return memberful_wp_user_downloads( $user_id );
+  return memberful_wp_user_downloads( $user_id ) ?: array();
 }
 
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -39,6 +39,9 @@ add_filter( 'memberful_wp_protect_content','wpautop');
 add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> reset priority
 add_filter('memberful_wp_protect_content','do_blocks',15);
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -39,10 +39,6 @@ add_filter( 'memberful_wp_protect_content','wpautop');
 add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
-<<<<<<< HEAD
 
 add_filter('memberful_wp_protect_content','do_blocks',15);
-=======
-add_filter('memberful_wp_protect_content','do_blocks',1);
->>>>>>> Update content_filter.php
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -39,6 +39,10 @@ add_filter( 'memberful_wp_protect_content','wpautop');
 add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
+<<<<<<< HEAD
 
 add_filter('memberful_wp_protect_content','do_blocks',15);
+=======
+add_filter('memberful_wp_protect_content','do_blocks',1);
+>>>>>>> Update content_filter.php
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -39,5 +39,9 @@ add_filter( 'memberful_wp_protect_content','wpautop');
 add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
+<<<<<<< HEAD
 add_filter('memberful_wp_protect_content','do_blocks',15);
+=======
+add_filter('memberful_wp_protect_content','do_blocks',1);
+>>>>>>> Update content_filter.php
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -39,13 +39,6 @@ add_filter( 'memberful_wp_protect_content','wpautop');
 add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
-<<<<<<< HEAD
-<<<<<<< HEAD
+
 add_filter('memberful_wp_protect_content','do_blocks',15);
-=======
-add_filter('memberful_wp_protect_content','do_blocks',1);
->>>>>>> Update content_filter.php
-=======
-add_filter('memberful_wp_protect_content','do_blocks',15);
->>>>>>> Update content_filter.php
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -40,8 +40,12 @@ add_filter( 'memberful_wp_protect_content','shortcode_unautop');
 add_filter( 'memberful_wp_protect_content','prepend_attachment');
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 add_filter('memberful_wp_protect_content','do_blocks',15);
 =======
 add_filter('memberful_wp_protect_content','do_blocks',1);
+>>>>>>> Update content_filter.php
+=======
+add_filter('memberful_wp_protect_content','do_blocks',15);
 >>>>>>> Update content_filter.php
 add_filter( 'memberful_wp_protect_content', 'do_shortcode', 11 );


### PR DESCRIPTION
Hi @northerner 

I've got a non-project-related pull request here that I think will help some of our mutual customers.

There are a couple of functions that throw Warnings based on functions returning empty strings instead of arrays when a logged-in user doesn't have a memberful account (e.g. a site admin, or editor). I've added a couple "elvis operators" in this pull request to ensure arrays are returned instead of empty strings.