### PR TITLE
Use MariaDB instead of MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,33 @@
-version: '3.3'
+version: "3.3"
 
 services:
-   db:
-     image: mysql:5.7
-     volumes:
-       - db_data:/var/lib/mysql
-     restart: always
-     environment:
-       MYSQL_ROOT_PASSWORD: somewordpress
-       MYSQL_DATABASE: wordpress
-       MYSQL_USER: wordpress
-       MYSQL_PASSWORD: wordpress
+  db:
+    image: mariadb:latest
+    volumes:
+      - db_data:/var/lib/mariadb
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: somewordpress
+      MARIADB_DATABASE: wordpress
+      MARIADB_USER: wordpress
+      MARIADB_PASSWORD: wordpress
 
-   wordpress:
-     depends_on:
-       - db
-     image: wordpress:latest
-     ports:
-       - "8181:80"
-     restart: always
-     env_file:
-       - envfile
-     volumes:
-       - "./wordpress:/var/www/html"
-       - ".:/root"
-       - "./site.conf:/etc/apache2/sites-available/000-default.conf"
-     extra_hosts:
-       - "apps.memberful.localhost:host-gateway"
-       - "ttf.memberful.localhost:host-gateway"
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:latest
+    ports:
+      - "8181:80"
+    restart: always
+    env_file:
+      - envfile
+    volumes:
+      - "./wordpress:/var/www/html"
+      - ".:/root"
+      - "./site.conf:/etc/apache2/sites-available/000-default.conf"
+    extra_hosts:
+      - "apps.memberful.localhost:host-gateway"
+      - "ttf.memberful.localhost:host-gateway"
 
 volumes:
-    db_data: {}
+  db_data: {}


### PR DESCRIPTION
The official Docker image for MySQL doesn't support the ARM architecture
thus it doesn't work with Apple M1 chips.

This change is a drop-in replacement. We could even keep using the old
`MYSQL_*` environment variables, but I changed them to `MARIADB_*` to be
more explicit.

- https://hub.docker.com/_/mariadb/
- https://hub.docker.com/_/mysql/