### PR TITLE
Prevent concurrent member mapping

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -81,7 +81,8 @@ class Memberful_Authenticator {
 
       $account = $this->get_member_data( $tokens->access_token );
 
-      $user = memberful_wp_sync_member_account( $account,  array( 'refresh_token' => $tokens->refresh_token ) );
+      $lock_timeout = 10;
+      $user = memberful_wp_sync_member_account( $account,  array( 'refresh_token' => $tokens->refresh_token ), $lock_timeout );
 
       if ( is_wp_error( $user ) ) {
         if ( $user->get_error_code() === 'user_already_exists' ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -2,6 +2,7 @@
 require_once MEMBERFUL_DIR.'/src/user/downloads.php';
 require_once MEMBERFUL_DIR.'/src/user/feeds.php';
 require_once MEMBERFUL_DIR.'/src/user/subscriptions.php';
+require_once MEMBERFUL_DIR.'/src/user/sync_lock.php';
 
 function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context = array() ) {
   $member_id = (int) $member_id;
@@ -24,14 +25,14 @@ function memberful_wp_sync_member_from_memberful( $member_id, $mapping_context =
  * @param $mapping_context
  * @return WP_User
  */
-function memberful_wp_sync_member_account( $account, $mapping_context ) {
-  $user = memberful_wp_sync_user( $account, $mapping_context );
+function memberful_wp_sync_member_account( $account, $mapping_context, $lock_timeout = null ) {
+  $user = memberful_wp_sync_user( $account, $mapping_context, $lock_timeout );
 
   if ( is_wp_error( $user ) ) {
     memberful_wp_record_wp_error( $user );
 
     if ( $user->get_error_code() === "duplicate_user_for_member" ) {
-      $user = memberful_wp_sync_user( $account, $mapping_context );
+      $user = memberful_wp_sync_user( $account, $mapping_context, $lock_timeout );
       return $user;
     }
   }
@@ -39,16 +40,25 @@ function memberful_wp_sync_member_account( $account, $mapping_context ) {
   return $user;
 }
 
-function memberful_wp_sync_user( $account, $mapping_context ) {
+function memberful_wp_sync_user( $account, $mapping_context, $lock_timeout ) {
   global $wpdb;
   $mapper = new Memberful_User_Map();
+  $member = $account->member;
+  $lock   = new Memberful_User_Sync_Lock($member->id, $lock_timeout);
+
+  if (!$lock->acquire()) {
+    if ($lock_timeout) {
+      return new WP_Error("memberful_lock_timeout", "The lock has timed out.", array("member_id" => $member->id));
+    } else {
+      return null;
+    }
+  }
 
   $wpdb->query( "START TRANSACTION" );
-
-  $user = $mapper->map( $account->member, $mapping_context );
+  $user = $mapper->map( $member, $mapping_context );
 
   if ( ! is_wp_error( $user ) ) {
-    if ( isset( $account->member->deleted ) ) {
+    if ( isset( $member->deleted ) ) {
       if ( memberful_is_safe_to_delete( $user ) ) {
         wp_delete_user( $user->ID );
         Memberful_User_Mapping_Repository::delete_mapping( $user->ID );
@@ -68,6 +78,8 @@ function memberful_wp_sync_user( $account, $mapping_context ) {
   } else {
     $wpdb->query( "ROLLBACK" );
   }
+
+  $lock->release();
 
   return $user;
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/sync_lock.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/sync_lock.php
@@ -1,0 +1,37 @@
+<?php
+
+class Memberful_User_Sync_Lock {
+
+  private $lock_timeout = 0;
+  private $member_id;
+
+  public function __construct($member_id, $lock_timeout = null) {
+    $this->member_id = $member_id;
+
+    if ($lock_timeout) {
+      $this->lock_timeout = $lock_timeout;
+    }
+  }
+
+  public function acquire() {
+    global $wpdb;
+
+    $statement = $wpdb->prepare("SELECT GET_LOCK(%s,%d) AS acquired", $this->lock_identifier(), $this->lock_timeout);
+    $lock_acquired = $wpdb->get_row($statement)->acquired;
+
+    return $lock_acquired === "1";
+  }
+
+  public function release() {
+    global $wpdb;
+
+    $statement = $wpdb->prepare("SELECT RELEASE_LOCK(%s)", $this->lock_identifier());
+    $wpdb->query($statement);
+  }
+
+  private function lock_identifier() {
+    $id = $this->member_id;
+
+    return "memberful-member-mapping-$id";
+  }
+}


### PR DESCRIPTION
A successful checkout can send up to three webhooks (new member,
subscription, and order), and now that the app sends webhooks in
parallel, it's possible for the plugin to create duplicate users because
of a race condition.

This commit prevents that by using an [explicit lock][1] scoped to the
member ID. The first request to acquire the lock performs the sync while
the others immediately give up.

When the request is made in an OAuth context, we wait up to 10 seconds
for the lock as we need to fetch a `User` instance to sign in.

https://3.basecamp.com/3293071/buckets/24350514/todos/4221739866

[1]: https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_get-lock