### PR TITLE
Ensure a redirect_to value is set for OAuth

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -107,6 +107,8 @@ class Memberful_Authenticator {
       );
     }
 
+    $redirect_to = get_home_url();
+
     if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
       $redirect_to = $_SERVER['HTTP_REFERER'];
     }


### PR DESCRIPTION
This change defaults the $redirect_to value to the site home URL for
cases where there is no HTTP_REFERER or redirect_to param passed with
the request.