### PR TITLE
Fix missing variable in compact call for ensure_user

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -146,7 +146,11 @@ class Memberful_User_Mapping_Ensure_User {
     $user_id = $this->user_exists ? $this->update_user() : $this->create_user();
 
     if ( is_wp_error( $user_id ) ) {
-      $user_id->add_data( array_merge( (array) $user_id->get_error_data(), compact('user_data') ) );
+      if (isset($user_data)) {
+        $user_id->add_data( array_merge( (array) $user_id->get_error_data(), compact('user_data') ) );
+      } else {
+        $user_id->add_data( array_merge( (array) $user_id->get_error_data(), array() ) );
+      }
 
       return $user_id;
     }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -146,11 +146,7 @@ class Memberful_User_Mapping_Ensure_User {
     $user_id = $this->user_exists ? $this->update_user() : $this->create_user();
 
     if ( is_wp_error( $user_id ) ) {
-      if (isset($user_data)) {
-        $user_id->add_data( array_merge( (array) $user_id->get_error_data(), compact('user_data') ) );
-      } else {
-        $user_id->add_data( array_merge( (array) $user_id->get_error_data(), array() ) );
-      }
+      $user_id->add_data( (array) $user_id->get_error_data() );
 
       return $user_id;
     }


### PR DESCRIPTION
To-do thread:

[Possible Bug — errors from our WP plugin logged by the customer — APKMirror](https://3.basecamp.com/3293071/buckets/5610905/todos/4838922987)

This PR fixes a PHP deprecation warning when calling `compact` in the `ensure_present` function.

The related deprecations:

[PHP 7.3: Warning on undefined variable names passed to compact](https://php.watch/versions/7.3/compact-warn-undefined-vars)
[PHP 8.1: Warning on compact function calls with non-string and non-array string parameters](https://php.watch/versions/8.1/compact-non-string-warning)

However, my approach to fix this may be inaccurate as I'm not too familiar with PHP's conventions. I'll fix it if there's a better to address this.