### PR TITLE
Fixed statically calling instance method `delete_mapping` in syncing.php

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/syncing.php
@@ -61,7 +61,7 @@ function memberful_wp_sync_user( $account, $mapping_context, $lock_timeout ) {
     if ( isset( $member->deleted ) ) {
       if ( memberful_is_safe_to_delete( $user ) ) {
         wp_delete_user( $user->ID );
-        Memberful_User_Mapping_Repository::delete_mapping( $user->ID );
+        (new Memberful_User_Mapping_Repository())->delete_mapping( $user->ID );
       } else {
         Memberful_Wp_User_Downloads::sync($user->ID, array());
         Memberful_Wp_User_Feeds::sync($user->ID, array());


### PR DESCRIPTION
[This PR fixes the following error caught by one of our customers, reported here](https://3.basecamp.com/3293071/buckets/5610905/todos/4704794719#__recording_4888828621):

`HP Fatal error:  Uncaught Error: Non-static method Memberful_User_Mapping_Repository::delete_mapping() cannot be called statically`

The following instance method, `delete_mapping`:

```php
// syncing.php

class Memberful_User_Mapping_Repository {
// ...

public function delete_mapping( $user_id ) {
  global $wpdb;

  return $wpdb->delete(self::table(), array( "wp_user_id" => $user_id ) );
}
```

is called statically in `syncing.php#63`:

```php
// ...
if ( memberful_is_safe_to_delete( $user ) ) {
  wp_delete_user( $user->ID );
  Memberful_User_Mapping_Repository::delete_mapping( $user->ID );
```

which is deprecated in PHP 8.0 and throws an error on calling: [PHP 8.0: Calling non-static class methods statically result in a fatal error](https://php.watch/versions/8.0/non-static-static-call-fatal-error)