### PR TITLE
Fix dev environment setup with new docker defaults

### DIFF
--- a/docker-provision.sh
+++ b/docker-provision.sh
@@ -2,8 +2,8 @@
 
 wp() {
   docker run -it --rm \
-    --volumes-from memberful-wp_wordpress_1 \
-    --network container:memberful-wp_wordpress_1 \
+    --volumes-from memberful-wp-wordpress-1 \
+    --network container:memberful-wp-wordpress-1 \
     --env-file envfile \
     --user 33:33 \
     wordpress:cli wp $@
@@ -15,6 +15,9 @@ wp core install \
   --admin_user=admin \
   --admin_password=admin \
   --admin_email=admin@example.com \
+
+echo "Installing twentytwentyone theme"
+wp theme install twentytwentyone --activate
 
 echo "Activating Memberful WP plugin"
 wp plugin activate memberful-wp


### PR DESCRIPTION
Updating the provisioning script to use new format container names and
install a default theme, since there is no longer any theme provided
with the container.