### PR TITLE
Check for `member` when processing order webhooks

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -14,7 +14,9 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
     $payload = json_decode($this->raw_request_body());
 
     if ( strpos( $payload->event, 'order' ) !== FALSE ) {
-      $member_id = (int) $payload->order->member->id;
+      if (isset($payload->order->member)) {
+        $member_id = (int) $payload->order->member->id;
+      }
 
       echo 'Processing order webhook for member '.$member_id;
     } elseif ( strpos( $payload->event, 'member' ) !== FALSE ) {


### PR DESCRIPTION
To-do: https://3.basecamp.com/3293071/buckets/5610905/todos/4945211415

Error message: https://sentry.io/share/issue/c1d9770e3aeb42069fa21c89ac1a2fb3/

---

When processing webhooks for the `order` event:

https://github.com/memberful/memberful-wp/blob/main/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php#L16

it is possible to receive a payload that does not contain the `member` attribute, [due to the way we define it here in our `builder` template.](https://github.com/memberful/memberful/blob/main/app/views/webhooks/order/_order.json.jbuilder#L6)

This does not throw an error but raises a warning in the logs.

This PR fixes the warning by checking for the existence of `member` before assigning. I used `isset` here for compatibility as null safe operators do not work for PHP 7 and below.