### PR TITLE
Remove unncessary error dump

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -4,22 +4,13 @@ global $wp_version;
 
 define( 'MEMBERFUL_API_USER_AGENT', 'WordPress/'.$wp_version.' (PHP '.phpversion().') memberful-wp/'.MEMBERFUL_VERSION );
 
-/**
- * Get details about a specific member via the API
- *
- * TODO: Clean this mess up.
- */
+// s
+/* Get details about a specific member via the API */
 function memberful_api_member( $member_id ) {
   $response = memberful_wp_get_data_from_api( memberful_admin_member_url( $member_id, MEMBERFUL_JSON ) );
 
   $response_code = (int) wp_remote_retrieve_response_code( $response );
   $response_body = wp_remote_retrieve_body( $response );
-
-  if ( is_wp_error( $response ) ) {
-    echo "Couldn't contact api: ";
-    var_dump( $response, $url );
-    die();
-  }
 
   if ( 200 !== $response_code OR empty( $response_body ) ) {
     return new WP_Error( 'memberful_fail', 'Could not get member info from api' );

--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -4,7 +4,6 @@ global $wp_version;
 
 define( 'MEMBERFUL_API_USER_AGENT', 'WordPress/'.$wp_version.' (PHP '.phpversion().') memberful-wp/'.MEMBERFUL_VERSION );
 
-// s
 /* Get details about a specific member via the API */
 function memberful_api_member( $member_id ) {
   $response = memberful_wp_get_data_from_api( memberful_admin_member_url( $member_id, MEMBERFUL_JSON ) );


### PR DESCRIPTION
`memberful_wp_get_data_from_api` already handles logging the error via `memberful_wp_instrument_api_call`, and this code path didn't work anyway since we removed the `$url` variable.

https://3.basecamp.com/3293071/buckets/5610905/todos/5301684835