### PR TITLE
Disconnect from Memberful app on uninstall

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -97,6 +97,12 @@ function memberful_wp_plugin_deactivate() {
 }
 register_deactivation_hook( __FILE__, 'memberful_wp_plugin_deactivate' );
 
+function memberful_wp_plugin_uninstall() {
+  memberful_api_disconnect();
+  memberful_wp_reset();
+}
+register_uninstall_hook(__FILE__, "memberful_wp_plugin_uninstall");
+
 function memberful_extend_auth_cookie_expiration( $expirein ) {
   if ( get_option( 'memberful_extend_auth_cookie_expiration' ) ) {
     return 60 * 60 * 24 * 365; // 1 year

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -150,8 +150,6 @@ function memberful_wp_reset() {
   foreach ( memberful_wp_connection_options() as $option ) {
     update_option( $option, $defaults[$option] );
   }
-
-  wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
 }
 
 function _memberful_wp_debug_all_post_meta() {
@@ -243,7 +241,10 @@ function memberful_wp_options() {
     }
 
     if ( isset( $_POST['reset_plugin'] ) ) {
-      return memberful_wp_reset();
+      memberful_api_disconnect();
+      memberful_wp_reset();
+
+      return wp_redirect( admin_url( 'options-general.php?page=memberful_options' ) );
     }
 
     if ( isset( $_POST['save_changes'] ) ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -18,6 +18,27 @@ function memberful_api_member( $member_id ) {
   return json_decode( $response_body );
 }
 
+/* Disconnect the WP integration in Memberful */
+function memberful_api_disconnect() {
+  $url = memberful_wp_wrap_api_token(memberful_disconnect_url());
+
+  $request = array(
+    "method"    => "DELETE",
+    "sslverify" => MEMBERFUL_SSL_VERIFY,
+    "headers"   => array(
+      "User-Agent" => MEMBERFUL_API_USER_AGENT,
+      "Accept" => "application/json"
+    ),
+    "timeout"   => 15
+  );
+
+  $response = wp_remote_request( $url, $request );
+
+  memberful_wp_instrument_api_call( $url, $request, $response );
+
+  return $response;
+}
+
 function memberful_wp_get_data_from_api( $url ) {
   $url = memberful_wp_wrap_api_token( $url );
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -16,6 +16,11 @@ function memberful_activation_url() {
   return MEMBERFUL_APPS_HOST.'/activate-app';
 }
 
+function memberful_disconnect_url() {
+  $url = memberful_url("admin/settings/integrate/website/wordpress", MEMBERFUL_JSON);
+  return add_query_arg("client_id", get_option("memberful_client_id"), $url);
+}
+
 function memberful_account_url( $format = MEMBERFUL_HTML ) {
   return memberful_url( 'account', $format );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -17,7 +17,7 @@ function memberful_activation_url() {
 }
 
 function memberful_disconnect_url() {
-  $url = memberful_url("admin/settings/integrate/website/wordpress", MEMBERFUL_JSON);
+  $url = MEMBERFUL_APPS_HOST.'/wordpress';
   return add_query_arg("client_id", get_option("memberful_client_id"), $url);
 }
 


### PR DESCRIPTION
When disconnecting the integration (in WP) or uninstalling the plugin, call an endpoint in the Memberful app to destroy the integration. This ensures we stop sending webhooks to sites that no longer use the plugin.

Also resets the plugin's connection credentials.

https://3.basecamp.com/3293071/buckets/5610677/todolists/5361289350