### PR TITLE
Update to Global Marketting feature

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/admin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/admin.js
@@ -11,9 +11,9 @@ jQuery(document).ready(function($){
 
     var target     = $('input[name="'+depends_on+'"]');
 
-	if ( ! target.length ) {
-	  target = $('select[name="'+depends_on+'"]');
-	}
+    if ( ! target.length ) {
+      target = $('select[name="'+depends_on+'"]');
+    }
 
     if ( ! target.length ) {
       target = $('#'+depends_on);
@@ -60,11 +60,11 @@ jQuery(document).ready(function($){
   });
 
   if(typeof tinyMCE !== 'undefined' && tinyMCE.editors.length){
-    
+
     let editor = tinyMCE.editors[0];
     let globalContent=$('#use_global_marketing_checkbox');
     let snippetContent=$('#use_global_snippets_checkbox');
-    
+
     function checkGlobalValidity(e){
       let isGlobal=globalContent.is(':checked');
       let isSnippets=snippetContent.is(':checked');
@@ -74,8 +74,8 @@ jQuery(document).ready(function($){
       let warning=$('#global_content_required');
 
       if( isGlobal && isContentEmpty ){
-       submit.prop('disabled', true);
-       warning.show();
+        submit.prop('disabled', true);
+        warning.show();
 
       } else {
         submit.prop('disabled', false);

--- a/wordpress/wp-content/plugins/memberful-wp/js/admin.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/admin.js
@@ -58,4 +58,35 @@ jQuery(document).ready(function($){
   $(document).on('pjax:complete', function() {
     $('[data-depends-on]').each(setupDependents);
   });
+
+  if(typeof tinyMCE !== 'undefined' && tinyMCE.editors.length){
+    
+    let editor = tinyMCE.editors[0];
+    let globalContent=$('#use_global_marketing_checkbox');
+    let snippetContent=$('#use_global_snippets_checkbox');
+    
+    function checkGlobalValidity(e){
+      let isGlobal=globalContent.is(':checked');
+      let isSnippets=snippetContent.is(':checked');
+      let submit=$('button[type="submit"]');
+      let isContentEmpty=!editor.getContent().trim();
+
+      let warning=$('#global_content_required');
+
+      if( isGlobal && isContentEmpty ){
+       submit.prop('disabled', true);
+       warning.show();
+
+      } else {
+        submit.prop('disabled', false);
+        warning.hide();
+
+      }
+    }
+
+    globalContent.change(checkGlobalValidity)
+    snippetContent.change(checkGlobalValidity)
+    editor.on('change', checkGlobalValidity);
+  }
+
 })

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* The “Default marketing content” setting has been moved to Settings → Memberful → Global marketing content. Previously, it was located underneath each of our marketing content boxes on posts, pages, tags, and categories.
+
 = 1.69.1 =
 
 * Fix PHP warnings

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -436,9 +436,6 @@ function memberful_wp_bulk_protect() {
       memberful_wp_set_post_available_to_anybody_subscribed_to_a_plan($id, $viewable_by_anybody_subscribed_to_a_plan);
     }
 
-    if( isset($_POST['memberful_make_default_marketing_content']) && $_POST['memberful_make_default_marketing_content'] )
-      memberful_wp_update_default_marketing_content( $marketing_content );
-
     wp_redirect( memberful_wp_plugin_bulk_protect_url() . '&success=bulk' );
   }
 
@@ -563,12 +560,14 @@ function memberful_wp_global_marketing() {
       update_option( 'memberful_use_global_marketing', true );
       update_option( 'memberful_global_marketing_override', filter_input( INPUT_POST, 'memberful_global_marketing_override', FILTER_SANITIZE_NUMBER_INT ) );
       update_option( 'memberful_global_marketing_content', filter_input( INPUT_POST, 'memberful_global_marketing_content' ) );
+      update_option ( 'memberful_use_global_snippets', isset($_POST['memberful_use_global_snippets']));
     } else {
       update_option( 'memberful_use_global_marketing', false );
     }
   }
 
   $use_global_marketing = get_option( 'memberful_use_global_marketing' );
+  $use_global_snippets = get_option( 'memberful_use_global_snippets');
   $global_marketing_content = get_option( 'memberful_global_marketing_content' );
   $global_marketing_override = get_option( 'memberful_global_marketing_override', true );
 
@@ -576,6 +575,7 @@ function memberful_wp_global_marketing() {
     'global_marketing',
     array(
       'use_global_marketing' => $use_global_marketing,
+      'use_global_snippets'  => $use_global_snippets,
       'global_marketing_content' => $global_marketing_content,
       'global_marketing_override' => $global_marketing_override,
       'form_target' => memberful_wp_plugin_global_marketing_url()

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -10,7 +10,6 @@ if(get_option('memberful_use_global_snippets')){
   add_filter( 'memberful_wp_protect_content', 'memberful_get_global_replacement', 1, 1 );
 }
 
-
 /**
  * Identify Post specific or global marketting content
  *

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -17,22 +17,18 @@ if(get_option('memberful_use_global_snippets')){
  * @return string
  */
 function memberful_get_global_replacement($marketting_content){
-  $override                         = get_option( 'memberful_global_marketing_override' );
-  $global_marketing_content         = get_option( 'memberful_global_marketing_content' );
+  $override = get_option( 'memberful_global_marketing_override' );
+  $global_marketing_content = get_option( 'memberful_global_marketing_content' );
 
-  //always send global is override
   if($override) {
     return $global_marketing_content;
   }
 
-  //Send global if post marketting is empty
   if(empty(trim($marketting_content))){
     return $global_marketing_content;
   }
 
-  //Send post marketting if neither of the above
   return $marketting_content;
-
 }
 
 /**
@@ -44,7 +40,7 @@ function memberful_get_global_replacement($marketting_content){
  */
 function memberful_apply_global_snippets_content_filter( $memberful_marketing_content ) {
   global $post;
-  $replacement=memberful_get_global_replacement($memberful_marketing_content);
+  $replacement = memberful_get_global_replacement($memberful_marketing_content);
 
   $wrapped_global_marketing_content = "<div class='memberful-global-marketting-content'>$replacement</div>";
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -4,20 +4,20 @@ define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
 define( 'MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
 
 function memberful_migrate_from_legacy_default(){
-  $legacy=get_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
+  $legacy = get_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
 
   if( empty($legacy) ){
     return;
   }
+
   //migrate to new settings
-  update_option('memberful_global_marketing_content', $legacy);
-  update_option('memberful_use_global_marketing', TRUE);
+  update_option( 'memberful_global_marketing_content', $legacy );
+  update_option( 'memberful_use_global_marketing', TRUE );
 
   //delete legacy option
   delete_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
 }
-
-add_action('admin_init', 'memberful_migrate_from_legacy_default');
+add_action( 'admin_init', 'memberful_migrate_from_legacy_default' );
 
 // Get marketing content for the frontend
 function memberful_marketing_content( $post_id ) {
@@ -51,5 +51,5 @@ function memberful_wp_update_term_marketing_content( $term_id, $content ) {
 }
 
 function memberful_wp_marketing_content_explanation() {
-  return apply_filters('memberful_marketing_content_explanation', '');
+  return apply_filters( 'memberful_marketing_content_explanation' , '' );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -1,7 +1,23 @@
 <?php
 
 define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
-define( 'MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
+define( 'MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
+
+
+
+function memberful_migrate_from_legacy_default(){
+  $legacy=get_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
+  
+  if( $legacy ){
+    return;
+  }
+  //migrate to new settings
+  update_option('memberful_global_marketing_content', $legacy);
+  update_option('memberful_use_global_marketing', TRUE);
+
+  //delete legacy option
+  delete_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
+}
 
 // Get marketing content for the frontend
 function memberful_marketing_content( $post_id ) {
@@ -34,14 +50,6 @@ function memberful_wp_update_term_marketing_content( $term_id, $content ) {
   update_term_meta( $term_id, MEMBERFUL_MARKETING_META_KEY, $content );
 }
 
-function memberful_wp_update_default_marketing_content( $content ) {
-  update_option( MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT, $content );
-}
-
-function memberful_wp_default_marketing_content() {
-  return stripslashes( get_option( MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT, '' ) );
-}
-
 function memberful_wp_marketing_content_explanation() {
-  return __( "This marketing content will be shown in place of your protected content to anyone who is not allowed to read the post..." );
+  return apply_filters('memberful_marketing_content_explanation', '');
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -19,6 +19,8 @@ function memberful_migrate_from_legacy_default(){
   delete_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
 }
 
+add_action('admin_init', 'memberful_migrate_from_legacy_default');
+
 // Get marketing content for the frontend
 function memberful_marketing_content( $post_id ) {
   $user_id = is_user_logged_in() ? get_current_user_id() : 0;

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -3,11 +3,9 @@
 define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
 define( 'MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
 
-
-
 function memberful_migrate_from_legacy_default(){
   $legacy=get_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
-  
+
   if( empty($legacy) ){
     return;
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -8,7 +8,7 @@ define( 'MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketi
 function memberful_migrate_from_legacy_default(){
   $legacy=get_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
   
-  if( $legacy ){
+  if( empty($legacy) ){
     return;
   }
   //migrate to new settings

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -48,7 +48,6 @@ function memberful_wp_metabox( $post ) {
 
   $marketing_content = array_filter(array(
     memberful_post_marketing_content( $post->ID ),
-    memberful_wp_default_marketing_content(),
     memberful_wp_marketing_content_explanation()
   ));
 
@@ -126,9 +125,6 @@ function memberful_wp_save_postdata( $post_id ) {
 
   memberful_wp_update_post_marketing_content( $post_id, $marketing_content );
 
-  if ( ! empty( $_POST['memberful_make_default_marketing_content'] ) ) {
-    memberful_wp_update_default_marketing_content( $marketing_content );
-  }
 }
 
 function memberful_wp_add_term_metabox( $term ) {
@@ -148,7 +144,6 @@ function memberful_wp_add_term_metabox( $term ) {
 
     $marketing_content = array_filter(array(
       memberful_term_marketing_content( $term->term_id ),
-      memberful_wp_default_marketing_content(),
       memberful_wp_marketing_content_explanation()
     ));
 
@@ -188,9 +183,6 @@ function memberful_wp_save_term_metadata( $term_id ) {
 
   memberful_wp_update_term_marketing_content( $term_id, $marketing_content );
 
-  if ( ! empty( $_POST['memberful_make_default_marketing_content'] ) ) {
-    memberful_wp_update_default_marketing_content( $marketing_content );
-  }
 }
 
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/options.php
@@ -22,9 +22,9 @@ function memberful_wp_all_options() {
     'memberful_filter_account_menu_items' => TRUE,
     'memberful_auto_sync_display_names' => FALSE,
     'memberful_use_global_marketing' => FALSE,
+    'memberful_use_global_snippets' => FALSE,
     'memberful_global_marketing_override' => TRUE,
-    'memberful_global_marketing_content' => '',
-    MEMBERFUL_OPTION_DEFAULT_MARKETING_CONTENT => NULL
+    'memberful_global_marketing_content' => ''
   );
 }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/options.php
@@ -22,7 +22,7 @@ function memberful_wp_all_options() {
     'memberful_filter_account_menu_items' => TRUE,
     'memberful_auto_sync_display_names' => FALSE,
     'memberful_use_global_marketing' => FALSE,
-    'memberful_use_global_snippets' => FALSE,
+    'memberful_use_global_snippets' => TRUE,
     'memberful_global_marketing_override' => TRUE,
     'memberful_global_marketing_content' => ''
   );

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -148,7 +148,7 @@ ul.memberful-global-restrict-access-required-list {
   margin: 2em 0;
 }
 #global_content_required{
-  display:none;
+  display: none;
 }
 
 /*---------------------------------------------------------

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -149,6 +149,7 @@ ul.memberful-global-restrict-access-required-list {
 }
 #global_content_required{
   display: none;
+  margin-bottom: 1em;
 }
 
 /*---------------------------------------------------------

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -144,6 +144,12 @@ ul.memberful-global-restrict-access-required-list {
 .memberful-bulk-apply-box label {
   margin-right: 5px;
 }
+#global_marketing_options hr{
+  margin: 2em 0;
+}
+#global_content_required{
+  display:none;
+}
 
 /*---------------------------------------------------------
 Global Marketing Tools

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -14,9 +14,8 @@
       if ( $use_global_marketing ) :
         ?>
         checked="checked"<?php endif; ?>>
-        <span class="memberful-label__text--multiline"><strong>Automatically pull an excerpt from each post.</strong>
-          <?php echo esc_html(' Memberful will pull the first two paragraphs from each protected post to use as marketing content for logged out visitors.'
-          .' This feature requires <p> tags in your posts to detect which content to use.');?>
+        <span class="memberful-label__text--multiline"><strong><?php _e('Turn on global marketing content', 'memberful') ?></strong>
+          <?php _e(' This setting allows you to create default marketing content to be displayed for all locked posts, pages, categories and tags.', 'memberful');?>
         </span>
       </label>
     </p>
@@ -39,12 +38,30 @@
       >
       Only use the global marketing content when other content doesn't exist.
       </label>
+      <hr>
+  
+      <div id="global_marketing_snippet_options">
+
+      <input id="use_global_snippets_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_snippets" 
+      <?php
+      if ( $use_global_snippets ) :
+        ?>
+        checked="checked"<?php endif; ?>>
+        <span class="memberful-label__text--multiline"><strong>Automatically pull an excerpt from each post.</strong>
+          <?php echo esc_html(' Memberful will pull the first two paragraphs from each protected post to use as marketing content for logged out visitors.'
+          .' This feature requires <p> tags in your posts to detect which content to use.');?>
+      </div>
+
     </div>
+
 
     <div class='global-marketing-content' data-depends-on="use_global_marketing_checkbox" data-depends-value="1">
       <?php wp_editor( $global_marketing_content, $editor_id = 'memberful_global_marketing_content', $settings = array() ); ?>
 
     </div>
+  </div>
+  <div id="global_content_required">
+    <?php _e('When using global marketting content, the marketing content box cannot be empty.', 'memberful'); ?>
   </div>
   <button type="submit" name="save_global_marketting" class="button button-primary">Save Changes</button>
   </form>

--- a/wordpress/wp-content/plugins/memberful-wp/views/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/metabox.php
@@ -13,10 +13,10 @@
 
       ?>
       <div class="memberful-marketing-content-description">
-        <label>
-          <input type="checkbox" name="memberful_make_default_marketing_content" value="1">
-          Make this the default marketing content for new posts, pages, tags and categories.
-        </label>
+        <a href="<?php echo admin_url('/options-general.php?page=memberful_options&subpage=global_marketing');?>">
+          Click Here
+        </a>
+         to manage global marketing content.
       </div>
     </div>
   </div>


### PR DESCRIPTION

- Updating  global marketing content settings
- Snippets are now optional
- Marketing content entry required (cannot be left blank when turned on)
- Migrates away from default content settings
- Per dropbox spec: https://www.dropbox.com/scl/fi/eaaknj0pootaiht4wq6l5/Memberful-WordPress-plugin-Updates-to-global-marketing-content.paper?dl=0&rlkey=n009qg03zyara3qgsvq5tly2l