### PR TITLE
Fix migration of default marketing content to global marketing content

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Fix migration of default marketing content to global marketing content. If you updated to version 1.70.0 before, please check your "Automatically pull an excerpt from each post" setting in Settings → Memberful → Global marketing content.
+
 = 1.70.0 =
 
 * The “Default marketing content” setting has been moved to Settings → Memberful → Global marketing content. Previously, it was located underneath each of our marketing content boxes on posts, pages, tags, and categories.

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -67,6 +67,25 @@ function memberful_wp_plugin_migrate_db() {
     $db_version = 2;
   }
 
+  if ( $db_version < 3 ) {
+    if ( get_option( 'memberful_use_global_marketing' ) ) {
+      add_option( 'memberful_use_global_snippets', TRUE );
+    } else {
+      $legacy_default_marketing_content = get_option( 'memberful_default_marketing_content', NULL );
+
+      if ( !empty( $legacy_default_marketing_content ) ) {
+        update_option( 'memberful_global_marketing_content', $legacy_default_marketing_content );
+        update_option( 'memberful_global_marketing_override', FALSE );
+        update_option( 'memberful_use_global_marketing', TRUE );
+        update_option( 'memberful_use_global_snippets', FALSE );
+
+        delete_option( 'memberful_default_marketing_content' );
+      }
+    }
+
+    $db_version = 3;
+  }
+
   update_option( 'memberful_db_version', $db_version );
 }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -1,23 +1,6 @@
 <?php
 
 define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
-define( 'MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT', 'memberful_default_marketing_content' );
-
-function memberful_migrate_from_legacy_default(){
-  $legacy = get_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
-
-  if( empty($legacy) ){
-    return;
-  }
-
-  //migrate to new settings
-  update_option( 'memberful_global_marketing_content', $legacy );
-  update_option( 'memberful_use_global_marketing', TRUE );
-
-  //delete legacy option
-  delete_option(MEMBERFUL_LEGACY_DEFAULT_MARKETING_CONTENT);
-}
-add_action( 'admin_init', 'memberful_migrate_from_legacy_default' );
 
 // Get marketing content for the frontend
 function memberful_marketing_content( $post_id ) {


### PR DESCRIPTION
The migration always overwrites global marketing content if a site uses
default marketing content because it doesn't check whether global
marketing content is enabled.

Also, the migration doesn't set all the necessary options.

This commit fixes it by checking the global marketing content settings
during migration and by setting all required options.

Also, I moved the migration to `memberful_wp_plugin_migrate_db()`. The
advantage is that this function uses DB versioning and keeps all
migration logic in one place.

People who have already updated to 1.70.0 should update to 1.70.1 and
check their global marketing settings. Especially the "Automatically
pull an excerpt from each post" one.

Fixes: https://3.basecamp.com/3293071/buckets/5610905/messages/5451161475#__recording_5557889732
