### PR TITLE
Add `home_url` to API disconnect request

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/api.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/api.php
@@ -21,6 +21,7 @@ function memberful_api_member( $member_id ) {
 /* Disconnect the WP integration in Memberful */
 function memberful_api_disconnect() {
   $url = memberful_wp_wrap_api_token(memberful_disconnect_url());
+  $url = add_query_arg("home_url", home_url(), $url);
 
   $request = array(
     "method"    => "DELETE",


### PR DESCRIPTION
Allows us to ignore disconnect requests coming from staging sites that were copied from production.

https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/5599054445