### PR TITLE
Do not pass `$_REQUEST` and `$_SERVER` to underlying methods

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints.php
@@ -20,11 +20,11 @@ add_action( 'wp_loaded', 'memberful_wp_endpoint_filter' );
  */
 function memberful_wp_endpoint_filter() {
   if ( $endpoint = memberful_wp_endpoint_for_request() ) {
-    if ( ! $endpoint->verify_request( $_SERVER['REQUEST_METHOD'] ) )
+    if ( ! $endpoint->verify_request() )
       die( 'Invalid request' );
 
     header('Cache-Control: private');
-    $endpoint->process( $_REQUEST, $_SERVER );
+    $endpoint->process();
     exit();
   }
 }
@@ -64,7 +64,7 @@ interface Memberful_Wp_Endpoint {
   /**
    * Allow the endpoint to process the request
    */
-  public function process( array $request_params, array $server_params );
+  public function process();
 
   /**
    * Checks if the request method is acceptable for this endpoint
@@ -73,5 +73,5 @@ interface Memberful_Wp_Endpoint {
    *
    * @return boolean True if request method is acceptable, else false
    */
-  public function verify_request( $request_method );
+  public function verify_request();
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/auth.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/auth.php
@@ -10,15 +10,15 @@ class Memberful_Wp_Endpoint_Auth implements Memberful_Wp_Endpoint {
   /**
    * Checks that the request to this endpoint is acceptable
    */
-  public function verify_request( $request_method ) {
-    return $request_method === 'GET';
+  public function verify_request() {
+    return $_SERVER['REQUEST_METHOD'] === 'GET';
   }
 
-  public function process( array $request_params, array $server_params ) {
-    if ( isset( $request_params['action'] ) && $request_params['action'] == 'logout' ) {
+  public function process() {
+    if ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] == 'logout' ) {
       wp_logout();
 
-      $redirect_to = $this->after_logout_redirect_url( $request_params );
+      $redirect_to = $this->after_logout_redirect_url();
     } else {
       $credentials = array( 'user_login' => '', 'user_password' => '', 'remember' => true );
 
@@ -28,21 +28,21 @@ class Memberful_Wp_Endpoint_Auth implements Memberful_Wp_Endpoint {
       $user = wp_signon( $credentials, is_ssl() );
       wp_set_current_user( $user->ID );
 
-      $redirect_to = $this->after_login_redirect_url( $request_params );
+      $redirect_to = $this->after_login_redirect_url();
     }
 
     wp_safe_redirect( $redirect_to );
   }
 
-  private function after_logout_redirect_url( $params ) {
-    $url = !empty( $params['redirect_to'] ) ? $params['redirect_to'] : home_url();
+  private function after_logout_redirect_url() {
+    $url = !empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : home_url();
 
     return apply_filters( 'memberful_wp_after_sign_out_url', $url );
   }
 
-  private function after_login_redirect_url( $params ) {
-    if ( isset( $params['redirect_to'] ) ) {
-      $url = $params['redirect_to'];
+  private function after_login_redirect_url() {
+    if ( isset( $_REQUEST['redirect_to'] ) ) {
+      $url = $_REQUEST['redirect_to'];
       $url = preg_match('/^https?%/', $url) ? urldecode($url) : $url;
     } else {
       $url = home_url();

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/check_test_cookie.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/check_test_cookie.php
@@ -1,11 +1,11 @@
 <?php
 
 class Memberful_Wp_Endpoint_Check_Test_Cookie implements Memberful_Wp_Endpoint {
-  public function verify_request( $request_method ) {
-    return $request_method === 'GET';
+  public function verify_request() {
+    return $_SERVER['REQUEST_METHOD'] === 'GET';
   }
 
-  public function process( array $request_params, array $server_params ) {
+  public function process() {
     if ( isset( $_COOKIE['memberful_cookie_test'] ) ) {
       Memberful_Wp_Reporting::report("Cookies test passed! Everything should work as expected.", "updated");
     } else {

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/debug.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/debug.php
@@ -1,11 +1,11 @@
 <?php
 
 class Memberful_Wp_Endpoint_Debug implements Memberful_Wp_Endpoint {
-  public function verify_request( $request_method ) {
+  public function verify_request() {
     if(!is_ssl())
       return false;
 
-    if($request_method !== "GET")
+    if($_SERVER['REQUEST_METHOD'] !== "GET")
       return false;
 
     $memberful_api_key = get_option( "memberful_api_key" );
@@ -24,7 +24,7 @@ class Memberful_Wp_Endpoint_Debug implements Memberful_Wp_Endpoint {
     return true;
   }
 
-  public function process( array $request_params, array $server_params ) {
+  public function process() {
     ob_start();
     memberful_wp_debug();
     print html_entity_decode( strip_tags( ob_get_clean() ), ENT_QUOTES );

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/set_test_cookie.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/set_test_cookie.php
@@ -1,11 +1,11 @@
 <?php
 
 class Memberful_Wp_Endpoint_Set_Test_Cookie implements Memberful_Wp_Endpoint {
-  public function verify_request( $request_method ) {
-    return $request_method === 'GET';
+  public function verify_request() {
+    return $_SERVER['REQUEST_METHOD'] === 'GET';
   }
 
-  public function process( array $request_params, array $server_params ) {
+  public function process() {
     setcookie(
       'memberful_cookie_test',
       'passed',

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -5,11 +5,11 @@
  */
 class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
 
-  public function verify_request( $request_method ) {
-    return $request_method === 'POST';
+  public function verify_request() {
+    return $_SERVER['REQUEST_METHOD'] === 'POST';
   }
 
-  public function process( array $request_params, array $server_params ) {
+  public function process() {
     $member_id  = NULL;
     $payload = json_decode($this->raw_request_body());
 


### PR DESCRIPTION
`$_REQUEST` and `$_SERVER` are super globals. It means that they are automatically available in all scopes.

We pass them to `Memberful_Wp_Endpoint` methods. It is unnecessary because these variables are already available everywhere, and we also don't need them most of the time.

Also, this introduces an indirection which makes security audits a bit harder. Instead of looking for `$_REQUEST` and `$_SERVER` variables, we need to follow the code flow, which is more complicated and error-prone.

This commit changes it by removing the indirection and using `$_REQUEST` and `$_SERVER` directly where needed.