### PR TITLE
Escape content before `echo`ing them

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/cron.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/cron.php
@@ -18,7 +18,7 @@ function memberful_wp_cron_sync_users() {
 
   $members_to_sync = Memberful_User_Mapping_Repository::fetch_ids_of_members_that_need_syncing();
 
-  echo "<pre>library=memberful_wp fn=memberful_wp_cron_sync_users at=start members=".count($members_to_sync)."\n</pre>";
+  echo "<pre>library=memberful_wp fn=memberful_wp_cron_sync_users at=start members=".intval(count($members_to_sync))."\n</pre>";
 
   foreach ( $members_to_sync as $member_id ) {
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -10,6 +10,8 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
   }
 
   public function process() {
+    header("Content-Type: text/plain");
+
     $member_id  = NULL;
     $payload = json_decode($this->raw_request_body());
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -20,15 +20,15 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
         $member_id = (int) $payload->order->member->id;
       }
 
-      echo 'Processing order webhook for member '.intval($member_id);
+      echo 'Processing order webhook for member '.$member_id;
     } elseif ( strpos( $payload->event, 'member' ) !== FALSE ) {
       $member_id = (int) $payload->member->id;
 
-      echo 'Processing member webhook for member '.intval($member_id);
+      echo 'Processing member webhook for member '.$member_id;
     } elseif ( strpos( $payload->event, 'subscription.' ) !== FALSE ) {
       $member_id = (int) $payload->subscription->member->id;
 
-      echo 'Processing subscription webhook for member '.intval($member_id);
+      echo 'Processing subscription webhook for member '.$member_id;
     } elseif ( strpos( $payload->event, 'subscription_plan' ) !== FALSE ) {
       memberful_wp_sync_subscription_plans();
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/webhook.php
@@ -20,15 +20,15 @@ class Memberful_Wp_Endpoint_Webhook implements Memberful_Wp_Endpoint {
         $member_id = (int) $payload->order->member->id;
       }
 
-      echo 'Processing order webhook for member '.$member_id;
+      echo 'Processing order webhook for member '.intval($member_id);
     } elseif ( strpos( $payload->event, 'member' ) !== FALSE ) {
       $member_id = (int) $payload->member->id;
 
-      echo 'Processing member webhook for member '.$member_id;
+      echo 'Processing member webhook for member '.intval($member_id);
     } elseif ( strpos( $payload->event, 'subscription.' ) !== FALSE ) {
       $member_id = (int) $payload->subscription->member->id;
 
-      echo 'Processing subscription webhook for member '.$member_id;
+      echo 'Processing subscription webhook for member '.intval($member_id);
     } elseif ( strpos( $payload->event, 'subscription_plan' ) !== FALSE ) {
       memberful_wp_sync_subscription_plans();
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/nav_menus.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/nav_menus.php
@@ -29,7 +29,7 @@ function memberful_nav_menu_items_meta_box() {
 function memberful_nav_menu_link_item($url, $label) { ?>
   <li>
     <label class="menu-item-title">
-      <input type="checkbox" name="memberful_link" class="menu-item-checkbox" data-url="<?php echo esc_attr($url); ?>" data-label="<?php echo esc_attr($label); ?>"> <?php echo($label); ?>
+      <input type="checkbox" name="memberful_link" class="menu-item-checkbox" data-url="<?php echo esc_attr($url); ?>" data-label="<?php echo esc_attr($label); ?>"> <?php echo esc_html($label); ?>
     </label>
   </li>
   <?php

--- a/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
@@ -105,7 +105,7 @@ function memberful_private_rss_feed_link($success_message = '', $error_message =
     $link = add_query_arg('category', $category, $link);
 
   if($success_message != '')
-    $link = '<a href="' . $link . '">' . do_shortcode($success_message) . '</a>';
+    $link = '<a href="' . esc_url($link) . '">' . do_shortcode($success_message) . '</a>';
 
   return memberful_private_rss_feed_link_response_helper($link, $return);
 }
@@ -114,7 +114,7 @@ function memberful_private_rss_feed_link_response_helper($response, $return = fa
   if($return)
     return $response;
 
-  echo $response;
+  echo wp_kses_post($response);
 
   return '';
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/widgets.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/widgets.php
@@ -77,8 +77,8 @@ if ( ! class_exists( 'Memberful_WP_Profile_Widget' ) ) :
       $title = ( isset( $instance[ 'title' ] ) ) ? $instance[ 'title' ] : 'Your account';
 ?>
     <p>
-      <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:' ); ?></label>
-      <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+      <label for="<?php echo esc_attr($this->get_field_id( 'title' )); ?>"><?php _e( 'Title:' ); ?></label>
+      <input class="widefat" id="<?php echo esc_attr($this->get_field_id( 'title' )); ?>" name="<?php echo esc_attr($this->get_field_name( 'title' )); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
     </p>
 <?php
     }
@@ -121,7 +121,7 @@ function memberful_wp_add_stylesheet_if_action() {
 
 function memberful_wp_format_widget_links( $links ) {
   foreach ( $links as $key => $link ) {
-    $links[$key] = '<a href="'.$link['href'].'" class="'.$link['class'].'">'.$link['text'].'</a>';
+    $links[$key] = '<a href="'.esc_url($link['href']).'" class="'.esc_attr($link['class']).'">'.esc_html($link['text']).'</a>';
   }
 
   return implode( ' <span class="memberful-links-separator">|</span> ', $links );

--- a/wordpress/wp-content/plugins/memberful-wp/views/acl_selection.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/acl_selection.php
@@ -23,7 +23,7 @@
             <?php foreach($subscriptions as $id => $subscription): ?>
               <li>
                 <label>
-                  <input type="checkbox" name="memberful_subscription_acl[]" value="<?php echo $id; ?>" <?php checked( $subscription['checked'] ); ?>>
+                  <input type="checkbox" name="memberful_subscription_acl[]" value="<?php echo esc_attr($id); ?>" <?php checked( $subscription['checked'] ); ?>>
                   <?php echo esc_html( $subscription['name'] ); ?>
                 </label>
               </li>
@@ -38,7 +38,7 @@
             <?php foreach($products as $id => $product): ?>
               <li>
                 <label>
-                  <input type="checkbox" name="memberful_product_acl[]" value="<?php echo $id; ?>" <?php checked( $product['checked'] ); ?>>
+                  <input type="checkbox" name="memberful_product_acl[]" value="<?php echo esc_attr($id); ?>" <?php checked( $product['checked'] ); ?>>
                   <?php echo esc_html( $product['name'] ); ?>
                 </label>
               </li>

--- a/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
@@ -2,7 +2,7 @@
   <?php memberful_wp_render('option_tabs', array('active' => 'advanced_settings')); ?>
   <?php memberful_wp_render('flash'); ?>
   <p><?php _e( "Assign roles to active (paying) and inactive (not paying) members. Memberful will automatically keep the role mappings in sync. Works best with custom roles created by other plugins.", 'memberful' ); ?></p>
-  <form method="post" action="<?php echo memberful_wp_plugin_advanced_settings_url( TRUE ); ?>">
+  <form method="post" action="<?php echo esc_url(memberful_wp_plugin_advanced_settings_url( TRUE )); ?>">
       <table class="widefat fixed" id="memberful-role-mapping-table">
         <thead>
         <tr>
@@ -13,11 +13,11 @@
         <tbody class="role-mapping">
           <?php foreach( $available_state_mappings as $state_id => $state): ?>
           <tr>
-            <td class="customer-state"><strong><?php echo $state['name']; ?></strong></td>
+            <td class="customer-state"><strong><?php echo esc_html($state['name']); ?></strong></td>
             <td class="mapped-role">
-              <select name="role_mappings[<?php echo $state_id; ?>]">
+              <select name="role_mappings[<?php echo esc_attr($state_id); ?>]">
                 <?php foreach( $available_roles as $role => $role_name ): ?>
-                <option value="<?php echo $role; ?>" <?php echo ($state['current_role'] === $role) ? 'selected="selected"' : '' ?>><?php echo $role_name; ?></option>
+                <option value="<?php echo esc_attr($role); ?>" <?php echo ($state['current_role'] === $role) ? 'selected="selected"' : '' ?>><?php echo esc_html($role_name); ?></option>
                 <?php endforeach; ?>
               </select>
             </td>

--- a/wordpress/wp-content/plugins/memberful-wp/views/bulk_protect.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/bulk_protect.php
@@ -16,7 +16,7 @@
     </div>
   <?php } ?>
 
-  <form method="POST" action="<?php echo $form_target ?>">
+  <form method="POST" action="<?php echo esc_url($form_target); ?>">
     <div class="memberful-bulk-apply-box">
       <h3><?php _e( "Bulk apply restrict access settings", 'memberful' ); ?></h3>
       <p>
@@ -32,12 +32,12 @@
           <option value="all_posts"><?php _e( "All Posts", 'memberful' ); ?></option>
           <option value="all_posts_from_category"><?php _e( "All Posts from a category or categories", 'memberful' ); ?></option>
           <?php foreach(memberful_additional_post_types_to_protect() as $post_type): ?>
-            <option value="<?php echo $post_type->name ?>"><?php echo $post_type->labels->all_items ?></option>
+            <option value="<?php echo esc_attr($post_type->name); ?>"><?php echo esc_html($post_type->labels->all_items); ?></option>
           <?php endforeach; ?>
         </select>
         <ul data-depends-on="global-restrict-target" data-depends-value="all_posts_from_category" class="memberful-global-restrict-access-category-list">
           <?php foreach(get_categories() as $category): ?>
-            <li><label><input type="checkbox"  name="memberful_protect_categories[]" value="<?php echo $category->cat_ID ?>"><?php echo $category->cat_name; ?></option></label></li>
+            <li><label><input type="checkbox"  name="memberful_protect_categories[]" value="<?php echo esc_attr($category->cat_ID); ?>"><?php echo esc_html($category->cat_name); ?></label></li>
       <?php endforeach; ?>
         </ul>
           <p>

--- a/wordpress/wp-content/plugins/memberful-wp/views/cookies_test.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/cookies_test.php
@@ -6,6 +6,6 @@
       Some web hosting services may block cookies or use extensive caching. This prevents Memberful from working properly. If the cookies test fails, please ask your hosting service to allow cookies from Memberful and also ask them to disable caching of URLs that start with <code><?php echo get_site_url(); ?>/?memberful_endpoint</code>.
     </p>
 
-    <a href="<?php echo memberful_wp_endpoint_url('set_test_cookie') ?>" class="button">Run Cookies Test</a>
+    <a href="<?php echo esc_url(memberful_wp_endpoint_url('set_test_cookie')); ?>" class="button">Run Cookies Test</a>
   </div>
 </div>

--- a/wordpress/wp-content/plugins/memberful-wp/views/debug.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/debug.php
@@ -22,24 +22,24 @@ PHP version: <?php echo phpversion(); ?>
 <?php endforeach; ?>
 
 # Stats
-Total users: <?php echo $total_users; ?>
+Total users: <?php echo intval($total_users); ?>
 
-Total mapping records: <?php echo $total_mapping_records ?>
+Total mapping records: <?php echo intval($total_mapping_records); ?>
 
-Total mapped users: <?php echo $total_mapped_users ?>
+Total mapped users: <?php echo intval($total_mapped_users); ?>
 
-Total unmapped users: <?php echo $total_unmapped_users ?>
+Total unmapped users: <?php echo intval($total_unmapped_users); ?>
 
 
 # Config
 <?php foreach($config as $key => $value): ?>
-<?php echo $key; ?>: <?php echo esc_html( var_export( $value, true )); ?>
+<?php echo esc_html($key); ?>: <?php echo esc_html( var_export( $value, true )); ?>
 
 <?php endforeach; ?>
 
 # ACL
 <?php foreach($acl_for_all_posts as $post_id => $meta): ?>
-<?php echo str_pad($post_id.':', 4); ?> <?php var_export($meta); ?>
+<?php echo str_pad(intval($post_id).':', 4); ?> <?php var_export($meta); ?>
 
 <?php endforeach; ?>
 
@@ -50,7 +50,7 @@ Unmapped users:
 <?php echo str_pad('WP ID', 6), ' ', str_pad('Email', 30), ' ', 'Date registered' ?>
 <?php foreach($unmapped_users as $unmapped_user): ?>
 
-<?php echo str_pad($unmapped_user->ID, 6) ?> <?php echo str_pad($unmapped_user->user_email, 30) ?> <?php echo $unmapped_user->user_registered; ?>
+<?php echo str_pad(intval($unmapped_user->ID), 6) ?> <?php echo str_pad(sanitize_email($unmapped_user->user_email), 30) ?> <?php echo $unmapped_user->user_registered; ?>
 <?php endforeach; ?>
 
 <?php endif; ?>
@@ -60,7 +60,7 @@ Mapping records:
 <?php echo str_pad('WP ID', 7), ' ', str_pad('Mem id', 7), ' ', str_pad('Last sync at', 32), ' ', str_pad('Refresh token', 32) ?>
 <?php foreach($mapping_records as $record): ?>
 
-<?php echo str_pad($record->wp_user_id, 7), ' ', str_pad($record->member_id, 7), ' ', str_pad(date('r', $record->last_sync_at), 32), ' ', str_pad($record->refresh_token, 32); ?>
+<?php echo str_pad(intval($record->wp_user_id), 7), ' ', str_pad(intval($record->member_id), 7), ' ', str_pad(date('r', $record->last_sync_at), 32), ' ', str_pad($record->refresh_token, 32); ?>
 <?php endforeach; ?>
 <?php endif; ?>
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/embed.js.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/embed.js.php
@@ -8,7 +8,7 @@
     var s = document.createElement('script');
     s.type = 'text/javascript';
     s.async = true;
-    s.src = '<?php echo $script_src; ?>';
+    s.src = '<?php echo esc_url($script_src); ?>';
 
     setup = function() { window.MemberfulEmbedded.setup(); };
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/flash.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/flash.php
@@ -1,7 +1,7 @@
 <?php if ( $message = Memberful_Wp_Reporting::pop() ): ?>
-<div class="notice is-dismissible <?php echo $message['type'] ?>">
+<div class="notice is-dismissible <?php echo esc_attr($message['type']); ?>">
   <p>
-    <?php echo $message['message'] ?>
+    <?php echo esc_html($message['message']); ?>
   </p>
 </div>
 <?php endif; ?>

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -2,7 +2,7 @@
   <?php memberful_wp_render( 'option_tabs', array( 'active' => 'global_marketing' ) ); ?>
   <?php memberful_wp_render( 'flash' ); ?>
 
-  <form method="POST" action="<?php echo $form_target; ?>">
+  <form method="POST" action="<?php echo esc_url($form_target); ?>">
   <?php memberful_wp_nonce_field( 'memberful_options' ); ?>
 
   <div class="memberful-bulk-apply-box">

--- a/wordpress/wp-content/plugins/memberful-wp/views/option_tabs.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/option_tabs.php
@@ -41,6 +41,6 @@ if ( is_plugin_active( 'bbpress/bbpress.php' ) ) {
 ?>
 <h2 class="nav-tab-wrapper">
 <?php foreach($links as $link): ?>
-  <a href="<?php echo $link['url']; ?>" id="nav_tab_<?php echo $link['id']; ?>" class="nav-tab <?php echo $link['id'] === $active ? 'nav-tab-active' : '' ?>"><?php echo $link['title']; ?></a>
+  <a href="<?php echo esc_url($link['url']); ?>" id="nav_tab_<?php echo esc_attr($link['id']); ?>" class="nav-tab <?php echo $link['id'] === $active ? esc_attr('nav-tab-active') : '' ?>"><?php echo esc_html($link['title']); ?></a>
 <?php endforeach; ?>
 </h2>

--- a/wordpress/wp-content/plugins/memberful-wp/views/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/options.php
@@ -6,7 +6,7 @@
       <h1><?php _e( 'Integration Active', 'memberful' ); ?></h1>
       <h2><?php printf( __( 'Syncing %d plans, %d downloads and %d podcasts.', 'memberful' ), count( $subscriptions ), count( $products ), count( $feeds ) ); ?></h2>
       <p><?php printf( __( '<a href="%s">Sign in to your Memberful account</a> to manage products, subscriptions, members, and orders.' ), memberful_url( 'admin' ) ) ?></p>
-      <form method="POST" action="<?php echo memberful_wp_plugin_settings_url(TRUE) ?>">
+      <form method="POST" action="<?php echo esc_url(memberful_wp_plugin_settings_url(TRUE)); ?>">
         <?php memberful_wp_nonce_field( 'memberful_options' ); ?>
         <button type="submit" name="manual_sync" class="button action"><?php _e( 'Run manual sync', 'memberful' ); ?></button>
         <button type="submit" name="reset_plugin" class="memberful-red-button"><?php _e( 'Disconnect', 'memberful' ); ?></button>
@@ -20,7 +20,7 @@
       <h1>Settings</h1>
       <p>Customize the appearance and behavior of the Memberful plugin.</p>
 
-      <form method="POST" action="<?php echo memberful_wp_plugin_settings_url(TRUE) ?>">
+      <form method="POST" action="<?php echo esc_url(memberful_wp_plugin_settings_url(TRUE)); ?>">
         <?php memberful_wp_nonce_field( 'memberful_options' ); ?>
         <p>
           <label for="extended_login_period_checkbox">

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
@@ -20,7 +20,7 @@ query_posts(array(
   'posts_per_page'  => get_option( 'posts_per_rss', 10 )
 ));
 
-echo '<?xml version="1.0" encoding="'.get_option('blog_charset').'"?'.'>';
+echo '<?xml version="1.0" encoding="'.esc_attr(get_option('blog_charset')).'"?'.'>';
 
 do_action( 'rss_tag_pre', 'rss2' );
 ?>
@@ -37,10 +37,10 @@ do_action( 'rss_tag_pre', 'rss2' );
     <?php endif; ?>
     <?php do_action('rss2_ns'); ?>>
   <channel>
-    <title><?php echo memberful_private_user_feed_title(); ?></title>
+    <title><?php echo esc_html(memberful_private_user_feed_title()); ?></title>
     <atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
     <link><?php bloginfo_rss('url') ?></link>
-    <description><?php echo memberful_private_user_feed_description(); ?></description>
+    <description><?php echo esc_html(memberful_private_user_feed_description()); ?></description>
     <lastBuildDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_lastpostmodified('GMT'), false); ?></lastBuildDate>
     <language><?php bloginfo_rss( 'language' ); ?></language>
     <?php if (get_option('memberful_add_block_tags_to_rss_feed')): ?>
@@ -58,7 +58,7 @@ $duration = 'hourly';
  * @param string $duration The update period. Accepts 'hourly', 'daily', 'weekly', 'monthly',
  *                         'yearly'. Default 'hourly'.
  */
-echo apply_filters( 'rss_update_period', $duration );
+echo esc_html(apply_filters( 'rss_update_period', $duration ));
 ?></sy:updatePeriod>
   <sy:updateFrequency><?php
 $frequency = '1';
@@ -71,7 +71,7 @@ $frequency = '1';
  * @param string $frequency An integer passed as a string representing the frequency
  *                          of RSS updates within the update period. Default '1'.
  */
-echo apply_filters( 'rss_update_frequency', $frequency );
+echo esc_html(apply_filters( 'rss_update_frequency', $frequency ));
 ?></sy:updateFrequency>
 <?php
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_settings.php
@@ -2,7 +2,7 @@
   <?php memberful_wp_render('option_tabs', array('active' => 'private_user_feed_settings')); ?>
   <?php memberful_wp_render('flash'); ?>
   <div id="memberful-wrap">
-    <form method="POST" action="<?php echo $form_target ?>">
+    <form method="POST" action="<?php echo esc_url($form_target); ?>">
       <div class="memberful-private-rss-feed-settings-box">
         <div class="postbox memberful-postbox">
           <fieldset>
@@ -16,7 +16,7 @@
                       <label>
                         <input type="checkbox"
                                name="memberful_private_feed_subscriptions[]"
-                               value="<?php echo $id; ?>"
+                               value="<?php echo esc_attr($id); ?>"
                               <?php checked(in_array($id, $current_feed_subscriptions));?>
                             >
                         <?php echo esc_html( $subscription['name'] ); ?>

--- a/wordpress/wp-content/plugins/memberful-wp/views/protect_bbpress.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/protect_bbpress.php
@@ -1,7 +1,7 @@
 <div class="wrap">
   <?php memberful_wp_render('option_tabs', array('active' => 'protect_bbpress')); ?>
   <?php memberful_wp_render('flash'); ?>
-  <form method="POST" action="<?php echo $form_target ?>">
+  <form method="POST" action="<?php echo esc_url($form_target); ?>">
     <?php memberful_wp_nonce_field( 'memberful_options' ); ?>
     <div class="memberful-bbpress-enable">
       <label>


### PR DESCRIPTION
* afee47f **Set content-type for webhook response**

* 483b6dd **Escape content before `echo`ing them**
  
  The methods used in this commit are:
  * [`esc_attr`][1]: for content that will be used as an HTML attribute
  * [`esc_html`][2]: for content that will be placed inside an HTML tag
  * [`esc_url`][3]: for content that will be used inside URL-related HTML
    attributes, like `src` and `href`
  * [`wp_kses_post`][4]: for content that will be used inside a post (or
    in post-like context)
  * [`intval`][5]: converts values to `int`
  
  https://3.basecamp.com/3293071/buckets/9856127/todos/5621905896
  
  [1]: https://developer.wordpress.org/reference/functions/esc_attr/
  [2]: https://developer.wordpress.org/reference/functions/esc_html/
  [3]: https://developer.wordpress.org/reference/functions/esc_url/
  [4]: https://developer.wordpress.org/reference/functions/wp_kses_post/
  [5]: https://www.php.net/manual/en/function.intval

* cafa6f9 **Revert `intval($member_id)`**
  
  I didn't notice we were already casting to `int` with `(int)`

