### PR TITLE
Sanitize, escape, and validate data

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -561,7 +561,10 @@ function memberful_wp_protect_bbpress() {
 
 function memberful_wp_private_rss_feed_settings() {
   if(isset($_POST['memberful_private_feed_subscriptions_submit'])) {
-    $private_feed_subscriptions = isset($_POST['memberful_private_feed_subscriptions']) ? $_POST['memberful_private_feed_subscriptions'] : false;
+    $private_feed_subscriptions = empty( $_POST['memberful_private_feed_subscriptions'] ) ? array() : (array) $_POST['memberful_private_feed_subscriptions'];
+    $private_feed_subscriptions = array_map( 'intval', $private_feed_subscriptions );
+    $private_feed_subscriptions = array_intersect( $private_feed_subscriptions, array_keys( memberful_subscription_plans() ) );
+
     $add_block_tags = isset($_POST['memberful_add_block_tags_to_rss_feed']);
 
     memberful_private_user_feed_settings_set_required_plan($private_feed_subscriptions);

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -414,48 +414,72 @@ function memberful_wp_advanced_settings() {
 function memberful_wp_bulk_protect() {
   if ( ! empty( $_POST ) ) {
     $categories_to_protect = empty( $_POST['memberful_protect_categories'] ) ? array() : (array) $_POST['memberful_protect_categories'];
+    $categories_to_protect = array_map( 'intval', $categories_to_protect );
+    $categories_to_protect = array_intersect( $categories_to_protect, get_categories( array( 'fields' => 'ids' ) ) );
+
     $acl_for_products = empty( $_POST['memberful_product_acl'] ) ? array() : (array) $_POST['memberful_product_acl'];
+    $acl_for_products = array_map( 'intval', $acl_for_products );
+    $acl_for_products = array_intersect( $acl_for_products, array_keys( memberful_downloads() ) );
+
     $acl_for_subscriptions = empty( $_POST['memberful_subscription_acl'] ) ? array() : (array) $_POST['memberful_subscription_acl'];
-    $marketing_content = empty( $_POST['memberful_marketing_content'] ) ? '' : $_POST['memberful_marketing_content'];
-    $things_to_protect = empty( $_POST['target_for_restriction']) ? '' : $_POST['target_for_restriction'];
-    $viewable_by_any_registered_user = empty( $_POST['memberful_viewable_by_any_registered_users'] ) ? '' : $_POST['memberful_viewable_by_any_registered_users'];
-    $viewable_by_anybody_subscribed_to_a_plan = empty( $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] ) ? '' : $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'];
+    $acl_for_subscriptions = array_map( 'intval', $acl_for_subscriptions );
+    $acl_for_subscriptions = array_intersect( $acl_for_subscriptions, array_keys( memberful_subscription_plans() ) );
+
+    $marketing_content = trim( wp_kses_post( $_POST['memberful_marketing_content'] ) );
+    $viewable_by_any_registered_user = isset( $_POST['memberful_viewable_by_any_registered_users'] );
+    $viewable_by_anybody_subscribed_to_a_plan = isset( $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] );
 
     $subscription_acl_manager = new Memberful_Post_ACL( Memberful_ACL::SUBSCRIPTION );
     $product_acl_manager = new Memberful_Post_ACL( Memberful_ACL::DOWNLOAD );
 
     $query_params = array('nopaging' => true, 'fields' => 'ids');
 
-    switch ( $things_to_protect ) {
-    case 'all_pages_and_posts':
-      $query_params['post_type'] = array('post', 'page');
-      break;
-    case 'all_pages':
-      $query_params['post_type'] = 'page';
-      break;
-    case 'all_posts':
-      $query_params['post_type'] = 'post';
-      break;
-    case 'all_posts_from_category':
-      $query_params['category__in'] = $categories_to_protect;
-      break;
-    default:
-      $query_params['post_type'] = $things_to_protect;
-    }
-
-    $query = new WP_Query($query_params);
-
-    foreach($query->posts as $id) {
-      $product_acl_manager->set_acl($id, $acl_for_products);
-      $subscription_acl_manager->set_acl($id, $acl_for_subscriptions);
-      if ( !empty($marketing_content) ) {
-        memberful_wp_update_post_marketing_content($id, $marketing_content);
+    if ( isset( $_POST['target_for_restriction'] ) ) {
+      switch ( $_POST['target_for_restriction'] ) {
+      case 'all_pages_and_posts':
+        $query_params['post_type'] = array('post', 'page');
+        break;
+      case 'all_pages':
+        $query_params['post_type'] = 'page';
+        break;
+      case 'all_posts':
+        $query_params['post_type'] = 'post';
+        break;
+      case 'all_posts_from_category':
+        if ( empty( $categories_to_protect ) ) {
+          $error = "Please select a category.";
+        } else {
+          $query_params['category__in'] = $categories_to_protect;
+        }
+        break;
+      default:
+        if ( in_array( $_POST['target_for_restriction'], array_keys( memberful_additional_post_types_to_protect() ) ) ) {
+          $query_params['post_type'] = $_POST['target_for_restriction'];
+        } else {
+          wp_die("Invalid request");
+        }
       }
-      memberful_wp_set_post_available_to_any_registered_users($id, $viewable_by_any_registered_user);
-      memberful_wp_set_post_available_to_anybody_subscribed_to_a_plan($id, $viewable_by_anybody_subscribed_to_a_plan);
+    } else {
+      wp_die("Invalid request");
     }
 
-    wp_redirect( memberful_wp_plugin_bulk_protect_url() . '&success=bulk' );
+    if ( empty( $error ) ) {
+      $query = new WP_Query($query_params);
+
+      foreach($query->posts as $id) {
+        $product_acl_manager->set_acl($id, $acl_for_products);
+        $subscription_acl_manager->set_acl($id, $acl_for_subscriptions);
+        if ( !empty($marketing_content) ) {
+          memberful_wp_update_post_marketing_content($id, $marketing_content);
+        }
+        memberful_wp_set_post_available_to_any_registered_users($id, $viewable_by_any_registered_user);
+        memberful_wp_set_post_available_to_anybody_subscribed_to_a_plan($id, $viewable_by_anybody_subscribed_to_a_plan);
+      }
+
+      wp_redirect( add_query_arg( 'success', 'bulk', memberful_wp_plugin_bulk_protect_url() ) );
+    } else {
+      wp_redirect( add_query_arg( 'error', $error, memberful_wp_plugin_bulk_protect_url() ) );
+    }
   }
 
   memberful_wp_render(

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -497,13 +497,21 @@ function memberful_wp_bulk_protect() {
 
 function memberful_wp_protect_bbpress() {
   if ( ! empty( $_POST ) ) {
-    $protection_enabled = empty( $_POST['memberful_protect_bbpress'] ) ? FALSE : ( $_POST['memberful_protect_bbpress'] == '1');
+    $protection_enabled = isset( $_POST['memberful_protect_bbpress'] );
+
     $required_downloads = empty( $_POST['memberful_product_acl'] ) ? array() : (array) $_POST['memberful_product_acl'];
+    $required_downloads = array_map( 'intval', $required_downloads );
+    $required_downloads = array_intersect( $required_downloads, array_keys( memberful_downloads() ) );
+
     $required_subscription_plans = empty( $_POST['memberful_subscription_acl'] ) ? array() : (array) $_POST['memberful_subscription_acl'];
-    $viewable_by_any_registered_user = empty( $_POST['memberful_viewable_by_any_registered_users'] ) ? FALSE : ($_POST['memberful_viewable_by_any_registered_users'] == '1');
-    $viewable_by_anybody_subscribed_to_a_plan = empty( $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] ) ? FALSE : ($_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] == '1');
-    $redirect_to_homepage = empty( $_POST['memberful_send_unauthorized_users'] ) ? TRUE : ($_POST['memberful_send_unauthorized_users'] == 'homepage');
-    $redirect_to_url = empty( $_POST['memberful_send_unauthorized_users_to_url'] ) ? '' : $_POST['memberful_send_unauthorized_users_to_url'];
+    $required_subscription_plans = array_map( 'intval', $required_subscription_plans );
+    $required_subscription_plans = array_intersect( $required_subscription_plans, array_keys( memberful_subscription_plans() ) );
+
+    $viewable_by_any_registered_user = isset( $_POST['memberful_viewable_by_any_registered_users'] );
+    $viewable_by_anybody_subscribed_to_a_plan = isset( $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] );
+
+    $redirect_to_homepage = empty( $_POST['memberful_send_unauthorized_users'] ) ? true : ($_POST['memberful_send_unauthorized_users'] == 'homepage');
+    $redirect_to_url = empty( $_POST['memberful_send_unauthorized_users_to_url'] ) ? '' : sanitize_url( $_POST['memberful_send_unauthorized_users_to_url'] );
 
     if ( ! empty( $required_subscription_plans ) )
       $required_subscription_plans = array_combine( $required_subscription_plans, $required_subscription_plans );

--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -110,12 +110,12 @@ class Memberful_Authenticator {
     $redirect_to = get_home_url();
 
     if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
-      $redirect_to = $_SERVER['HTTP_REFERER'];
+      $redirect_to = wp_sanitize_redirect( $_SERVER['HTTP_REFERER'] );
     }
 
     // Allow overriding of redirect location
     if ( isset( $_REQUEST['redirect_to'] ) ) {
-      $redirect_to = $_REQUEST['redirect_to'];
+      $redirect_to = wp_sanitize_redirect( $_REQUEST['redirect_to'] );
     }
 
     // Send the user to Memberful

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/auth.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/auth.php
@@ -35,14 +35,14 @@ class Memberful_Wp_Endpoint_Auth implements Memberful_Wp_Endpoint {
   }
 
   private function after_logout_redirect_url() {
-    $url = !empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : home_url();
+    $url = !empty( $_REQUEST['redirect_to'] ) ? wp_sanitize_redirect( $_REQUEST['redirect_to'] ) : home_url();
 
     return apply_filters( 'memberful_wp_after_sign_out_url', $url );
   }
 
   private function after_login_redirect_url() {
     if ( isset( $_REQUEST['redirect_to'] ) ) {
-      $url = $_REQUEST['redirect_to'];
+      $url = wp_sanitize_redirect ( $_REQUEST['redirect_to'] );
       $url = preg_match('/^https?%/', $url) ? urldecode($url) : $url;
     } else {
       $url = home_url();

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -100,17 +100,15 @@ function memberful_wp_save_postdata( $post_id ) {
     $post_id = $parent_id;
   }
 
-  $entities = array( Memberful_ACL::DOWNLOAD, Memberful_ACL::SUBSCRIPTION );
+  $download_ids = array_map( 'intval', (array) $_POST['memberful_product_acl'] );
+  $download_ids = array_intersect( $download_ids, array_keys(memberful_downloads()) );
+  $acl_manager = new Memberful_Post_ACL( 'product' );
+  $acl_manager->set_acl( $post_id, $download_ids );
 
-  foreach ( $entities as $entity ) {
-    $field = 'memberful_'.$entity.'_acl';
-
-    $acl_list = empty($_POST[$field]) ? array() : (array) $_POST[$field];
-
-    $acl_manager = new Memberful_Post_ACL( $entity );
-
-    $acl_manager->set_acl( $post_id, $acl_list );
-  }
+  $subscription_plan_ids = array_map( 'intval', (array) $_POST['memberful_subscription_acl'] );
+  $subscription_plan_ids = array_intersect( $subscription_plan_ids, array_keys(memberful_subscription_plans()) );
+  $acl_manager = new Memberful_Post_ACL( 'subscription' );
+  $acl_manager->set_acl( $post_id, $subscription_plan_ids );
 
   $viewable_by_any_registered_users = isset($_POST['memberful_viewable_by_any_registered_users']) && $_POST['memberful_viewable_by_any_registered_users'] === '1';
   memberful_wp_set_post_available_to_any_registered_users( $post_id, $viewable_by_any_registered_users );
@@ -158,17 +156,15 @@ function memberful_wp_save_term_metadata( $term_id ) {
   if ( ! memberful_wp_valid_nonce( plugin_basename( __FILE__ ) ) )
     return;
 
-  $entities = array( Memberful_ACL::DOWNLOAD, Memberful_ACL::SUBSCRIPTION );
+  $download_ids = array_map( 'intval', (array) $_POST['memberful_product_acl'] );
+  $download_ids = array_intersect( $download_ids, array_keys( memberful_downloads() ) );
+  $acl_manager = new Memberful_Term_ACL( 'product' );
+  $acl_manager->set_acl( $term_id, $download_ids );
 
-  foreach ( $entities as $entity ) {
-    $field = 'memberful_'.$entity.'_acl';
-
-    $acl_list = empty($_POST[$field]) ? array() : (array) $_POST[$field];
-
-    $acl_manager = new Memberful_Term_ACL( $entity );
-
-    $acl_manager->set_acl( $term_id, $acl_list );
-  }
+  $subscription_plan_ids = array_map( 'intval', (array) $_POST['memberful_subscription_acl'] );
+  $subscription_plan_ids = array_intersect( $subscription_plan_ids, array_keys( memberful_subscription_plans() ) );
+  $acl_manager = new Memberful_Term_ACL( 'subscription' );
+  $acl_manager->set_acl( $term_id, $subscription_plan_ids );
 
   $viewable_by_any_registered_users = isset($_POST['memberful_viewable_by_any_registered_users']) && $_POST['memberful_viewable_by_any_registered_users'] === '1';
   memberful_wp_set_term_available_to_any_registered_users( $term_id, $viewable_by_any_registered_users );

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -119,7 +119,7 @@ function memberful_wp_save_postdata( $post_id ) {
   if(!isset($_POST['memberful_marketing_content']))
     return;
 
-  $marketing_content = trim( $_POST['memberful_marketing_content'] );
+  $marketing_content = trim( wp_kses_post( $_POST['memberful_marketing_content'] ) );
 
   memberful_wp_update_post_marketing_content( $post_id, $marketing_content );
 
@@ -175,10 +175,9 @@ function memberful_wp_save_term_metadata( $term_id ) {
   if(!isset($_POST['memberful_marketing_content']))
     return;
 
-  $marketing_content = trim( $_POST['memberful_marketing_content'] );
+  $marketing_content = trim( wp_kses_post( $_POST['memberful_marketing_content'] ) );
 
   memberful_wp_update_term_marketing_content( $term_id, $marketing_content );
-
 }
 
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/private_user_feed.php
@@ -21,7 +21,7 @@ function memberful_private_user_feed_init() {
     return;
 
   // Extract the token from the URL
-  $feedUserToken = $_GET['member-feed'];
+  $feedUserToken = sanitize_text_field( $_GET['member-feed'] );
 
   $requiredPlan = memberful_private_user_feed_settings_get_required_plan();
 
@@ -34,8 +34,8 @@ function memberful_private_user_feed_init() {
   // We'll take "all" users with the token match.
   $user_query = new WP_User_Query(
     array(
-      'meta_key'	  =>	'memberful_private_user_feed_token',
-      'meta_value'	=>	$feedUserToken
+      'meta_key' => 'memberful_private_user_feed_token',
+      'meta_value' => $feedUserToken
     )
   );
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/bulk_protect.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/bulk_protect.php
@@ -2,15 +2,19 @@
   <?php memberful_wp_render('option_tabs', array('active' => 'bulk_protect')); ?>
   <?php memberful_wp_render('flash'); ?>
 
-  <?php if( isset( $_GET['success'] ) && $_GET['success'] == 'bulk' ) :  ?>
+  <?php if( isset( $_GET['success'] ) && $_GET['success'] == 'bulk' ) { ?>
     <div class="updated notice">
       <p><?php _e( "Bulk restrictions have been applied successfully.", 'memberful' ); ?></p>
     </div>
-  <?php else : ?>
+  <?php } elseif( isset( $_GET['error'] ) ) { ?>
+    <div class="error notice">
+      <p><?php echo esc_html( $_GET['error'] ); ?></p>
+    </div>
+  <?php } else { ?>
     <div class="update-nag">
       <?php _e( "<strong>Be careful:</strong> When you bulk apply these restrict access settings we will <strong>overwrite and replace</strong> any specified individual Post or Page restrict access settings.", 'memberful' ); ?>
     </div>
-  <?php endif; ?>
+  <?php } ?>
 
   <form method="POST" action="<?php echo $form_target ?>">
     <div class="memberful-bulk-apply-box">

--- a/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/private_user_feed_content.php
@@ -11,6 +11,7 @@ remove_filter('the_content', 'memberful_wp_protect_content', 100);
 
 $post_types = array("post");
 $category = $_GET['category'] ?? '';
+$category = sanitize_term_field( 'slug', $category, 0, 'category', 'db' );
 
 query_posts(array(
   'category__in'    => apply_filters( 'memberful_private_rss_category_ids', array() ),


### PR DESCRIPTION
https://3.basecamp.com/3293071/buckets/9856127/todos/5621901887

---

* ccca242 **Validate $_POST['memberful_product_acl'] and $_POST['memberful_subscription_acl'] in src/metabox.php**

* 396f9e6 **Sanitize $_POST['memberful_marketing_content'] in src/metabox.php**

* c676e62 **Sanitize and validate POST inputs in `memberful_wp_bulk_protect()`**

* 6a4b21b **Sanitize and validate POST inputs in `memberful_wp_protect_bbpress()`**

* 65fe53f **Validate POST inputs in `memberful_wp_private_rss_feed_settings()`**

* 1d71c95 **Sanitize values from `$_GET['category']`**

* c5d6b58 **Sanitize redirect URLs with `wp_sanitize_redirect()`**

* d0a52d7 **Sanitize `$_GET['member-feed']`**
  
  This seems unnecessary because we pass it to `WP_Query` which should
  sanitize it.
  
  However, I'm afraid that we need to do this anyway to make sure we pass
  the security audit.

