### PR TITLE
Return the current content if `$post` is empty in `content_filter.php`

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -5,6 +5,12 @@ add_action( 'the_content', 'memberful_wp_protect_content', 100 );
 function memberful_wp_protect_content( $content ) {
   global $post;
 
+  if ( !isset( $post ) ) {
+    # Return the content since we're not in the loop if `$post` is `NULL`
+    # Temporary fix for Elasticpress' syncing issue
+    return $content;
+  }
+
   if(doing_filter('memberful_wp_protect_content')){
     return $content;
   }


### PR DESCRIPTION
It is possible for the global `$post` variable to be `null` when `memberful_wp_protect_content` is executed, as demonstrated in this scenario: https://3.basecamp.com/3293071/buckets/9856127/todos/5712180926

This happens when the function [runs outside of the Wordpress loop](https://codex.wordpress.org/The_Loop). When this happens, we can assume the function runs in a context that may not require content protection as in the to-do above (syncing post content in Elasticsearch). Hence, we can just return the current `$content` as it is.

Please feel free to suggest alternatives or point out any gotchas in this approach if I missed any! Thank you!