### PR TITLE
Allow iframes in marketing content

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -430,7 +430,7 @@ function memberful_wp_bulk_protect() {
     $acl_for_subscriptions = array_map( 'intval', $acl_for_subscriptions );
     $acl_for_subscriptions = array_intersect( $acl_for_subscriptions, array_keys( memberful_subscription_plans() ) );
 
-    $marketing_content = trim( wp_kses_post( $_POST['memberful_marketing_content'] ) );
+    $marketing_content = trim( memberful_wp_kses_post( $_POST['memberful_marketing_content'] ) );
     $viewable_by_any_registered_user = isset( $_POST['memberful_viewable_by_any_registered_users'] );
     $viewable_by_anybody_subscribed_to_a_plan = isset( $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] );
 
@@ -628,7 +628,7 @@ function memberful_wp_global_marketing() {
     if ( isset( $_POST['memberful_use_global_marketing'] ) ) {
       update_option( 'memberful_use_global_marketing', true );
       update_option( 'memberful_global_marketing_override', filter_input( INPUT_POST, 'memberful_global_marketing_override', FILTER_SANITIZE_NUMBER_INT ) );
-      update_option( 'memberful_global_marketing_content', filter_input( INPUT_POST, 'memberful_global_marketing_content' ) );
+      update_option( 'memberful_global_marketing_content', memberful_wp_kses_post( $_POST['memberful_global_marketing_content'] ) );
       update_option( 'memberful_use_global_snippets', (int) isset($_POST['memberful_use_global_snippets']));
     } else {
       update_option( 'memberful_use_global_marketing', false );

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/sfwd-learndash.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/sfwd-learndash.php
@@ -96,7 +96,7 @@ class Memberful_Wp_Integration_Sfwd_Learndash {
    * @return string
    */
   function memberful_wp_protect_learndash_content( $content, $post_id ) {
-    $memberful_marketing_content = wp_kses_post( memberful_marketing_content( $post_id ) );
+    $memberful_marketing_content = memberful_wp_kses_post( memberful_marketing_content( $post_id ) );
     return apply_filters( 'memberful_wp_protect_content', $memberful_marketing_content );
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/woocommerce.php
@@ -70,7 +70,7 @@ class Memberful_Wp_Integration_WooCommerce {
   }
 
   function memberful_wp_protect_woo_content( $post_id ) {
-    $memberful_marketing_content = wp_kses_post( memberful_marketing_content( $post_id ) );
+    $memberful_marketing_content = memberful_wp_kses_post( memberful_marketing_content( $post_id ) );
     return apply_filters( 'memberful_wp_protect_content', $memberful_marketing_content );
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/core-ext.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/core-ext.php
@@ -40,6 +40,25 @@ function memberful_wp_allowed_hosts( $hosts ) {
   return $hosts;
 }
 
+function memberful_wp_kses_post( $string ) {
+  $allowed_html = array_merge(
+    wp_kses_allowed_html( 'post' ),
+    array(
+      'iframe' => array(
+        'allow' => true,
+        'allowfullscreen' => true,
+        'frameborder' => true,
+        'height' => true,
+        'loading' => true,
+        'src' => true,
+        'width' => true
+      )
+    )
+  );
+
+  return wp_kses( $string, $allowed_html );
+}
+
 function memberful_wp_render( $template, array $vars = array() ) {
   extract( $vars );
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -121,7 +121,7 @@ function memberful_wp_save_postdata( $post_id ) {
   if(!isset($_POST['memberful_marketing_content']))
     return;
 
-  $marketing_content = trim( wp_kses_post( $_POST['memberful_marketing_content'] ) );
+  $marketing_content = trim( memberful_wp_kses_post( $_POST['memberful_marketing_content'] ) );
 
   memberful_wp_update_post_marketing_content( $post_id, $marketing_content );
 
@@ -179,7 +179,7 @@ function memberful_wp_save_term_metadata( $term_id ) {
   if(!isset($_POST['memberful_marketing_content']))
     return;
 
-  $marketing_content = trim( wp_kses_post( $_POST['memberful_marketing_content'] ) );
+  $marketing_content = trim( memberful_wp_kses_post( $_POST['memberful_marketing_content'] ) );
 
   memberful_wp_update_term_marketing_content( $term_id, $marketing_content );
 }


### PR DESCRIPTION
This adds `iframe` to the HTML tags allowed by `wp_kses`, so that customers don't need to use a separate plugin to enable iframes in marketing content (e.g. for Spotify trailers).

It also matches the sanitization applied in the global content editor to the post and bulk restrict editors.