### PR TITLE
Check whether member is deleted before calling `Memberful_User_Map#map`

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -20,20 +20,7 @@ class Memberful_User_Map {
    */
   public function map( $member, array $context = array() ) {
     if (isset($member->deleted)) {
-      $mapping_from_member = $this->repository()->find_user_member_is_mapped_to($member);
-
-      if ($mapping_from_member['mapping_exists']) {
-        return $mapping_from_member['user'];
-      } else {
-        return $this->add_data_to_wp_error(
-          new WP_Error(
-            'user_does_not_exist',
-            'The Wordpress user with the given member_id does not exist',
-            array('member_id' => $member->id)
-          ),
-          compact('member')
-        );
-      }
+      return $this->map_deleted_member($member);
     }
 
     $existing_user_with_members_email = get_user_by( 'email', $member->email );
@@ -130,6 +117,23 @@ class Memberful_User_Map {
     }
   }
 
+  private function map_deleted_member($member) {
+    $mapping_from_member = $this->repository()->find_user_member_is_mapped_to($member);
+
+    if ($mapping_from_member['mapping_exists']) {
+      return $mapping_from_member['user'];
+    } else {
+      return $this->add_data_to_wp_error(
+        new WP_Error(
+          'user_does_not_exist',
+          'The Wordpress user with the given member_id does not exist',
+          array('member_id' => $member->id)
+        ),
+        compact('member')
+      );
+    }
+  }
+
   private function add_data_to_wp_error( WP_Error $error, array $data ) {
     $error_data = (array) $error->get_error_data();
 
@@ -145,7 +149,6 @@ class Memberful_User_Map {
 
     return $this->_repository;
   }
-
 }
 
 class Memberful_User_Mapping_Ensure_User {

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -19,6 +19,23 @@ class Memberful_User_Map {
    * @return WP_User
    */
   public function map( $member, array $context = array() ) {
+    if (isset($member->deleted)) {
+      $mapping_from_member = $this->repository()->find_user_member_is_mapped_to($member);
+
+      if ($mapping_from_member['mapping_exists']) {
+        return $mapping_from_member['user'];
+      } else {
+        return $this->add_data_to_wp_error(
+          new WP_Error(
+            'user_does_not_exist',
+            'The Wordpress user with the given member_id does not exist',
+            array('member_id' => $member->id)
+          ),
+          compact('member')
+        );
+      }
+    }
+
     $existing_user_with_members_email = get_user_by( 'email', $member->email );
 
     $mapping_from_member = $this->repository()->find_user_member_is_mapped_to( $member );


### PR DESCRIPTION
To-do: https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/6411081563

---

When calling `Memberful_User_Map#map`, it is possible for the compiler to raise a `Undefined property` warning when operating on deleted members. A few samples of the error are linked in the to-do.

This happens because the payload for deleted members from the Memberful API only returns the member `id` and a `deleted` property.

The errors happen in the following lines:

https://github.com/memberful/memberful-wp/blob/fde48841f661045be0e423ede192d7ff0a12d2a4/wordpress/wp-content/plugins/memberful-wp/src/user/map.php#L22

https://github.com/memberful/memberful-wp/blob/fde48841f661045be0e423ede192d7ff0a12d2a4/wordpress/wp-content/plugins/memberful-wp/src/user/map.php#L188-L194

This PR fixes the warning by checking whether the member is deleted in `Memberful_User_Map#map`. 

If a `WP_User` with the given member `id` exists, we return it immediately.

If it doesn't exist, we return a `WP_Error` which is caught in `memberful_wp_sync_user`:

https://github.com/memberful/memberful-wp/blob/fde48841f661045be0e423ede192d7ff0a12d2a4/wordpress/wp-content/plugins/memberful-wp/src/syncing.php#L45

I'm open to feedback or suggestions on fixing this differently. Thank you!