### PR TITLE
Fix deprecated string interpolation syntax

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -49,6 +49,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Fix PHP deprecation warnings.
+
 = 1.73.5 =
 
 * Restored previously reverted fix for PHP warnings when mapping deleted members in Memberful_User_Map#map

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -5,8 +5,8 @@ add_action( 'save_post', 'memberful_wp_save_postdata' );
 
 function memberful_setup_taxonomy_hooks( $taxonomy, $object_type, $arguments ) {
   if ( $arguments['public'] && $arguments['show_in_menu'] ) {
-    add_action( "${taxonomy}_edit_form", 'memberful_wp_add_term_metabox' );
-    add_action( "edited_${taxonomy}", 'memberful_wp_save_term_metadata' );
+    add_action( "{$taxonomy}_edit_form", 'memberful_wp_add_term_metabox' );
+    add_action( "edited_{$taxonomy}", 'memberful_wp_save_term_metadata' );
   }
 }
 add_action( 'registered_taxonomy', 'memberful_setup_taxonomy_hooks', 10, 3 );


### PR DESCRIPTION
The old syntax is deprecated since PHP 8.2.

See:
- https://php.watch/versions/8.2/%24%7Bvar%7D-string-interpolation-deprecated
- https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing

Fixes: https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/7252740605