### PR TITLE
Update the release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ version. For example we need to do this after updating "Tested up to" in
 `readme.txt`. To do this simply follow the release instructions above without
 updating the plugin version.
 
+### Updating assets for the WordPress plugin page
+
+Very occasionally we may need to update the assets for the WordPress plugin. This
+includes the banner image, the icon, and the screenshots. To do this:
+
+* Update the assets in the `assets` directory.
+* Run `./release.sh --assets`.
+
 ## Rolling back
 
 * Revert your changes.

--- a/release.sh
+++ b/release.sh
@@ -74,7 +74,7 @@ push_to_wordpress_svn() {
     fi
   done
 
-  echo "Commiting to trunk"
+  echo "Committing to trunk"
   svn commit -m "$SVN_COMMIT_MESSAGE"
 
   echo "Tagging version $VERSION"
@@ -85,7 +85,26 @@ push_to_wordpress_svn() {
   svn copy trunk tags/$VERSION
   cd tags/$VERSION
   svn commit -m "$SVN_COMMIT_MESSAGE"
+}
 
+push_assets_to_wordpress_svn() {
+  echo "Creating local copy of SVN repo in $SVN_LOCAL_PATH"
+  svn co "$SVN_URL/assets" $SVN_LOCAL_PATH/assets
+
+  rsync -a --delete --exclude ".svn" "$PWD/assets/" "$SVN_LOCAL_PATH/assets"
+
+  cd $SVN_LOCAL_PATH/assets
+
+  echo "Adding new files to assets"
+  svn status | grep "^?" | awk '{print $2}' | xargs -r svn add
+  echo "Removing old files from assets"
+  svn status | grep "^\!" | awk '{print $2}' | xargs -r svn remove
+
+  echo "Committing to assets"
+  svn commit -m "Updated assets"
+}
+
+cleanup() {
   echo "Removing temporary directory $SVN_LOCAL_PATH"
   rm -fr $SVN_LOCAL_PATH
 }
@@ -94,6 +113,13 @@ check_current_branch
 check_for_uncommitted_changes
 check_version_definitions
 ask_for_release_confirmation
-push_to_wordpress_svn
+
+if [ "$1" == "--assets" ]; then
+  push_assets_to_wordpress_svn
+else
+  push_to_wordpress_svn
+fi
+
+cleanup
 
 echo "Done!"

--- a/release.sh
+++ b/release.sh
@@ -60,19 +60,15 @@ push_to_wordpress_svn() {
   echo "Creating local copy of SVN repo in $SVN_LOCAL_PATH"
   svn co $SVN_URL $SVN_LOCAL_PATH
 
+  rsync -a --delete --exclude ".svn" "$PLUGIN_DIR/" "$SVN_TRUNK_PATH"
+
+  cd $SVN_LOCAL_PATH
+
   echo "Adding new files to trunk"
-  cp -r $PLUGIN_DIR/* $SVN_TRUNK_PATH
-  cd $SVN_TRUNK_PATH
-  svn status | grep "^?" | awk '{print $2}' | xargs svn add
+  svn status | grep "^?" | awk '{print $2}' | xargs -r svn add
 
   echo "Removing old files from trunk"
-  cd $SVN_TRUNK_PATH
-
-  find . -type f | while read FILE; do
-    if [ ! -e $PLUGIN_DIR/$FILE ]; then
-      svn remove "$FILE"
-    fi
-  done
+  svn status | grep "^\!" | awk '{print $2}' | xargs -r svn remove
 
   echo "Committing to trunk"
   svn commit -m "$SVN_COMMIT_MESSAGE"


### PR DESCRIPTION
* f8195fa **Extend the release script to handle asset updates**
  
  This was already tested with [#355][1].
  
  [1]: https://github.com/memberful/memberful-wp/pull/355

* ad4436a **Refactor file synchronization and SVN operations in release script**
  
  Replace `cp` with `rsync` for efficient file handling, add `-r` to
  `xargs` to prevent errors with empty inputs, and streamline SVN
  add/remove commands to enhance robustness and reduce error likelihood.

