### PR TITLE
Reduce number of tags in the SVN repository

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -81,12 +81,11 @@ push_to_wordpress_svn() {
   svn copy trunk tags/$VERSION
   cd tags/$VERSION
   svn commit -m "$SVN_COMMIT_MESSAGE"
-}
 
-  # Keep only the latest 20 tags
+  # Keep only the latest 10 tags
   echo "Checking and removing old tags if necessary"
   cd $SVN_LOCAL_PATH/tags
-  TAGS_TO_DELETE=$(svn ls | sort -t. -k1,1nr -k2,2nr -k3,3nr | tail -n +21)
+  TAGS_TO_DELETE=$(svn ls | sort -t. -k1,1nr -k2,2nr -k3,3nr | tail -n +11)
 
   if [ ! -z "$TAGS_TO_DELETE" ]; then
     echo "Removing old tags..."

--- a/release.sh
+++ b/release.sh
@@ -83,6 +83,18 @@ push_to_wordpress_svn() {
   svn commit -m "$SVN_COMMIT_MESSAGE"
 }
 
+  # Keep only the latest 20 tags
+  echo "Checking and removing old tags if necessary"
+  cd $SVN_LOCAL_PATH/tags
+  TAGS_TO_DELETE=$(svn ls | sort -t. -k1,1nr -k2,2nr -k3,3nr | tail -n +21)
+
+  if [ ! -z "$TAGS_TO_DELETE" ]; then
+    echo "Removing old tags..."
+    echo "$TAGS_TO_DELETE" | xargs -I {} svn remove {}
+    svn commit -m "Remove old tags"
+  fi
+}
+
 push_assets_to_wordpress_svn() {
   echo "Creating local copy of SVN repo in $SVN_LOCAL_PATH"
   svn co "$SVN_URL/assets" $SVN_LOCAL_PATH/assets


### PR DESCRIPTION
This will speed up plugin releases because we checkout the whole repository every time we run the release script.

Fixes: https://3.basecamp.com/3293071/buckets/9856127/todos/7278826549

See also: https://developer.wordpress.org/plugins/wordpress-org/plugin-developer-faq/#how-many-old-releases-should-i-keep-in-svn