### PR TITLE
replace invalid aria role attributes with data attributes

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -41,19 +41,19 @@ function memberful_wp_shortcode_buy_gift_link( $atts, $content ) {
 
 
 function memberful_wp_shortcode_register_link( $atts, $content ) {
-  return '<a href="'.memberful_registration_page_url().'" role="register">'.do_shortcode($content).'</a>';
+  return '<a href="'.memberful_registration_page_url().'" data-memberful-link-type="register">'.do_shortcode($content).'</a>';
 }
 
 function memberful_wp_shortcode_sign_out_link( $atts, $content ) {
-  return '<a href="'.memberful_sign_out_url().'" role="sign_out">'.do_shortcode($content).'</a>';
+  return '<a href="'.memberful_sign_out_url().'" data-memberful-link-type="sign_out">'.do_shortcode($content).'</a>';
 }
 
 function memberful_wp_shortcode_sign_in_link( $atts, $content ) {
-  return '<a href="'.memberful_sign_in_url().'" role="sign_in">'.do_shortcode($content).'</a>';
+  return '<a href="'.memberful_sign_in_url().'" data-memberful-link-type="sign_in">'.do_shortcode($content).'</a>';
 }
 
 function memberful_wp_shortcode_account_link( $atts, $content ) {
-  return '<a href="'.memberful_account_url().'" role="account">'.do_shortcode($content).'</a>';
+  return '<a href="'.memberful_account_url().'" data-memberful-link-type="account">'.do_shortcode($content).'</a>';
 }
 
 function memberful_wp_shortcode_feeds_link( $atts, $content ) {


### PR DESCRIPTION
The shortcodes for showing Memberful sign-in, sign-out, register, and account links all have invalid ARIA `role` attributes. These don't appear to be used anywhere in the plugin or in the [embed.js](https://js.memberful.com/embed.js) script, so I think they can be safely removed. I can, however, see how they could be helpful for styling or JS targeting, so replacing them with custom `data` attributes is a better way to do that.