### PR TITLE
Pin WP docker image version to 6.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:latest
+    image: wordpress:6.4.0-php8.0
     ports:
       - "8181:80"
     restart: always

--- a/docker-provision.sh
+++ b/docker-provision.sh
@@ -27,7 +27,7 @@ wp config set MEMBERFUL_APPS_HOST "http://apps.memberful.localhost"
 wp config set MEMBERFUL_EMBED_HOST "http://js.memberful.localhost"
 wp config set MEMBERFUL_SSL_VERIFY false --raw
 
-if [ -x "$(command -v puma-dev)" ]; then 
-  echo "Adding puma-dev entry for wordpress.locahost"
+if [ -x "$(command -v puma-dev)" ]; then
+  echo "Adding puma-dev entry for wordpress.localhost"
   echo 8181 > ~/.puma-dev/wordpress
 fi


### PR DESCRIPTION
WP updated Debian to 12 on versions >= 6.4.1, and it seems like it broke something on our container's DNS resolution—it can no longer reach the Rails app using puma-dev's subdomains (like apps.memberful.localhost)

I've spend a few hours trying to solve this but ultimately couldn't.

This commit pins the docker image version to the last one using Debian 11. Despite pinning WP to 6.4.0, `wp cli core install` installs the latest version, allowing us to test our plugin with the most recent WP.

We should find a long term fix for this, but for the time being, this will allow us to work on the plugin.

https://3.basecamp.com/3293071/buckets/9856127/todos/7308233397