### PR TITLE
Mitigate XSS vector in shortcodes

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -111,6 +111,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Sanitize and escape shortcode output (#365)
+
 = 1.73.7 =
 
 * Ensure `memberful_error_log` option is always an array (#363)

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -27,10 +27,14 @@ function memberful_wp_shortcode_buy_subscription_link( $atts, $content ) {
   $url = add_query_arg( 'plan', $plan_id, memberful_url( 'checkout' ) );
 
   if( isset( $atts['price'] ) ) {
-    $url = add_query_arg( 'price', $atts['price'], $url );
+    $price = filter_var($atts['price'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+
+    if( $price !== false && $price > 0 ) {
+      $url = add_query_arg( 'price', $price, $url );
+    }
   }
 
-  return '<a href="'.$url.'">'.do_shortcode($content).'</a>';
+  return '<a href="' . esc_url($url) . '">' . do_shortcode($content) . '</a>';
 }
 
 function memberful_wp_shortcode_buy_gift_link( $atts, $content ) {
@@ -60,10 +64,14 @@ function memberful_wp_shortcode_feeds_link( $atts, $content ) {
   $url = memberful_feeds_url();
 
   if (!empty($atts['podcast'])) {
-    $url = add_query_arg('id', $atts['podcast'], $url);
+    $podcast_id = filter_var($atts['podcast'], FILTER_VALIDATE_INT);
+
+    if ($podcast_id !== false && $podcast_id > 0) {
+      $url = add_query_arg('id', $podcast_id, $url);
+    }
   }
 
-  return '<a href="'.$url.'">'.do_shortcode($content).'</a>';
+  return '<a href="' . esc_url($url) . '">' . do_shortcode($content) . '</a>';
 }
 
 function memberful_wp_shortcode_download_link( $atts, $content) {


### PR DESCRIPTION
Sanitize user-supplied params before adding them to the URL, escape the full URL, and only then return it.

https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/7870245467

filter_var: https://www.php.net/manual/en/function.filter-var.php
filters and flags: https://www.php.net/manual/en/filter.filters.sanitize.php
esc_url: https://developer.wordpress.org/reference/functions/esc_url/