### PR TITLE
Check if user exists before returning it

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -111,6 +111,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Check if WP User exists when mapping deleted Memberful members (#366)
+
 = 1.73.8 =
 
 * Sanitize and escape shortcode output (#365)

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -120,7 +120,7 @@ class Memberful_User_Map {
   private function map_deleted_member($member) {
     $mapping_from_member = $this->repository()->find_user_member_is_mapped_to($member);
 
-    if ($mapping_from_member['mapping_exists']) {
+    if ($mapping_from_member['mapping_exists'] && $mapping_from_member['user'] !== FALSE) {
       return $mapping_from_member['user'];
     } else {
       return $this->add_data_to_wp_error(


### PR DESCRIPTION
The plugin has a table that maps Memberful members to WP users. However, when a WP user is deleted (like from the WP dashboard), we don't delete the mapping.

When a webhook (or sign-in attempt) comes in for a member that is already mapped, we try to fetch the WP user, and if it doesn't exist, we create a new one.

This works most of the time, except with `member.deleted` webhooks, where we don't check if the WP User exists, and it eventually raises an error.

This commit fixes this by checking if the WP user exists before returning the mapping. If it doesn't, since the member was deleted, we don't need to create it again.

https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/7870254896