### PR TITLE
Do not include protected posts in search results

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -46,6 +46,7 @@ require_once MEMBERFUL_DIR . '/src/widgets.php';
 require_once MEMBERFUL_DIR . '/src/endpoints.php';
 require_once MEMBERFUL_DIR . '/src/marketing_content.php';
 require_once MEMBERFUL_DIR . '/src/content_filter.php';
+require_once MEMBERFUL_DIR . '/src/search_filter.php';
 require_once MEMBERFUL_DIR . '/src/entities.php';
 require_once MEMBERFUL_DIR . '/src/embed.php';
 require_once MEMBERFUL_DIR . '/src/api.php';

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -111,6 +111,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Exclude protected posts from search results
+
 = 1.73.9 =
 
 * Check if WP User exists when mapping deleted Memberful members (#366)

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -411,8 +411,8 @@ function _memberful_wp_posts_with_terms( $terms ) {
     );
   }
 
-  if (count( $tax_query ) > 1) {
-    $tax_query = array_merge( array('relation' => 'OR'), $tax_query );
+  if ( count( $tax_query ) > 1 ) {
+    $tax_query = array_merge( array( 'relation' => 'OR' ), $tax_query );
   }
 
   return get_posts( array( 'tax_query' => $tax_query, 'fields' => 'ids', 'numberposts' => -1 ) );
@@ -423,7 +423,7 @@ function _memberful_wp_group_terms_by_taxonomy( $term_ids ) {
 
   $grouped_terms = array();
 
-  foreach ($terms as $term) {
+  foreach ( $terms as $term ) {
     $grouped_terms[$term->taxonomy][] = $term->term_id;
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -5,11 +5,45 @@ require_once MEMBERFUL_DIR . '/src/acl/term_options.php';
 
 /**
  * Returns an array of post IDs that the user is not allowed to access.
+ * Includes posts disallowed by both Post ACL and Term ACL.
+ *
+ * @return array An array of post IDs that the user is not allowed to access.
+ */
+function memberful_wp_user_disallowed_post_ids( $user_id ) {
+  $user_posts = _memberful_wp_items_from_acl(
+    get_option( 'memberful_acl', array() ),
+    $user_id,
+    memberful_wp_posts_for_subscribers(),
+    memberful_wp_posts_for_registered_users()
+  );
+
+  $user_terms = _memberful_wp_items_from_acl(
+    get_option( 'memberful_term_acl', array() ),
+    $user_id,
+    memberful_wp_terms_for_subscribers(),
+    memberful_wp_terms_for_registered_users()
+  );
+
+  $posts_allowed_by_terms = _memberful_wp_posts_with_terms( $user_terms['allowed'] );
+  $posts_restricted_by_terms = _memberful_wp_posts_with_terms( $user_terms['restricted'] );
+
+  // Merge posts disallowed by Post ACL and Term ACL
+  $disallowed_posts = array_unique( array_merge( $user_posts['restricted'], $posts_restricted_by_terms ) );
+
+  // Remove posts allowed by Post ACL or Term ACL
+  $disallowed_posts = array_diff( $disallowed_posts, $user_posts['allowed'], $posts_allowed_by_terms );
+
+  return $disallowed_posts;
+}
+
+/**
+ * Returns an array of post IDs that the user is not allowed to access.
+ * Includes only posts disallowed by Post ACL, not Term ACL.
  *
  * @return array An associative array where the keys and values are post IDs
  *               that the user is not allowed to access.
  */
-function memberful_wp_user_disallowed_post_ids( $user_id ) {
+function memberful_wp_post_ids_disallowed_by_post_acl( $user_id ) {
   static $cache = array();
 
   if ( isset( $cache[$user_id] ) ) {
@@ -357,4 +391,41 @@ function memberful_supported_taxonomies() {
   $taxonomies = get_taxonomies( array( "public" => true, "show_in_menu" => true ) );
 
   return $taxonomies;
+}
+
+function _memberful_wp_posts_with_terms( $terms ) {
+  if ( empty( $terms )) {
+    return array();
+  }
+
+  $tax_query = array();
+
+  $grouped_terms = _memberful_wp_group_terms_by_taxonomy( $terms );
+
+  foreach ( $grouped_terms as $taxonomy => $term_ids ) {
+    $tax_query[] = array(
+      'taxonomy' => $taxonomy,
+      'field'    => 'term_id',
+      'terms'    => $term_ids,
+      'operator' => 'IN',
+    );
+  }
+
+  if (count( $tax_query ) > 1) {
+    $tax_query = array_merge( array('relation' => 'OR'), $tax_query );
+  }
+
+  return get_posts( array( 'tax_query' => $tax_query, 'fields' => 'ids', 'numberposts' => -1 ) );
+}
+
+function _memberful_wp_group_terms_by_taxonomy( $term_ids ) {
+  $terms = get_terms( array( 'include' => $term_ids, 'hide_empty' => false) );
+
+  $grouped_terms = array();
+
+  foreach ($terms as $term) {
+    $grouped_terms[$term->taxonomy][] = $term->term_id;
+  }
+
+  return $grouped_terms;
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/marketing_content.php
@@ -4,8 +4,8 @@ define( 'MEMBERFUL_MARKETING_META_KEY', 'memberful_marketing_content' );
 
 // Get marketing content for the frontend
 function memberful_marketing_content( $post_id ) {
-  $user_id = is_user_logged_in() ? get_current_user_id() : 0;
-  $restricted_posts = memberful_wp_user_disallowed_post_ids( $user_id );
+  $user_id = get_current_user_id();
+  $restricted_posts = memberful_wp_post_ids_disallowed_by_post_acl( $user_id );
 
   if ( isset( $restricted_posts[$post_id] )) {
     $marketing_content = memberful_post_marketing_content( $post_id );

--- a/wordpress/wp-content/plugins/memberful-wp/src/search_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/search_filter.php
@@ -1,0 +1,16 @@
+<?php
+
+add_action( 'pre_get_posts', 'memberful_wp_protect_search' );
+
+function memberful_wp_protect_search( $query ) {
+  if ( !is_admin() && $query->is_search() ) {
+    $disallowed_post_ids = memberful_wp_user_disallowed_post_ids( get_current_user_id() );
+
+    // Exclude posts that the user is not allowed to see.
+    if ( ! empty( $disallowed_post_ids ) ) {
+      $excluded_post_ids = $query->get( 'post__not_in', array() );
+
+      $query->set( 'post__not_in', array_merge( $excluded_post_ids, $disallowed_post_ids ) );
+    }
+  }
+}


### PR DESCRIPTION
Build an array of all posts a user cannot see and use it to exclude these posts from search results.

Based on #368.

More information: https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/8080735578