### PR TITLE
Disable the `bkismet_check_signup` filter on WordPress.com

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -111,6 +111,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Improve member synchronization on sites hosted on WordPress.com
+
 = 1.74.1 =
 
 * Allow admins to see protected posts in search results


### PR DESCRIPTION
This filter is automatically added to sites running on WordPress.com. It is designed to block signups that appear suspicious or spam-like; however, it also blocks legitimate email addresses.

Since the users we try to create in WordPress already exist in Memberful, it is safe to disable the filter when syncing users from Memberful to a WordPress site.

Fixes: https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/8294998242