### PR TITLE
Refactor search protection logic in `memberful_wp_protect_search`

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -111,6 +111,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 == Changelog ==
 
+= unreleased =
+
+* Improve compatibility with Oxygen Builder
+
 = 1.74.1 =
 
 * Allow admins to see protected posts in search results

--- a/wordpress/wp-content/plugins/memberful-wp/src/search_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/search_filter.php
@@ -3,19 +3,30 @@
 add_action( 'pre_get_posts', 'memberful_wp_protect_search' );
 
 function memberful_wp_protect_search( $query ) {
-  // Do not filter search results for admins
-  if ( current_user_can( 'publish_posts' ) ) {
-    return $query;
+  // Do not protect admin pages.
+  if ( is_admin() ) {
+    return;
   }
 
-  if ( !is_admin() && $query->is_search() ) {
-    $disallowed_post_ids = memberful_wp_user_disallowed_post_ids( get_current_user_id() );
+  // Protect only search queries.
+  if ( !$query->is_search() ) {
+    return;
+  }
 
-    // Exclude posts that the user is not allowed to see.
-    if ( ! empty( $disallowed_post_ids ) ) {
-      $excluded_post_ids = $query->get( 'post__not_in', array() );
+  // Allow admins to see all posts.
+  //
+  // Call `current_user_can` only after confirming it's a search query,
+  // as WordPress should be fully loaded by then.
+  if ( current_user_can( 'publish_posts' ) ) {
+    return;
+  }
 
-      $query->set( 'post__not_in', array_merge( $excluded_post_ids, $disallowed_post_ids ) );
-    }
+  $disallowed_post_ids = memberful_wp_user_disallowed_post_ids( get_current_user_id() );
+
+  // Exclude posts the user is not allowed to see.
+  if ( ! empty( $disallowed_post_ids ) ) {
+    $excluded_post_ids = $query->get( 'post__not_in', array() );
+
+    $query->set( 'post__not_in', array_merge( $excluded_post_ids, $disallowed_post_ids ) );
   }
 }


### PR DESCRIPTION
`pre_get_posts` can run (*) before WordPress is fully loaded, which may cause `current_user_can` to fail since it depends on `wp_get_current_user`, which might not be available yet. This issue occurs when plugins call `get_posts` before the init hook.

To prevent this, call `current_user_can` only after confirming that the query is a search query, ensuring that WordPress is fully loaded by then.

* For example, Oxygen Builder stores its templates as custom post types and it loads them with `get_posts` before WordPress fully initializes.

Fixes: https://3.basecamp.com/3293071/buckets/5610905/card_tables/cards/8325445010