### PR TITLE
Chore: Update PHP and WP version compatibility 

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
+++ b/wordpress/wp-content/plugins/memberful-wp/memberful-wp.php
@@ -3,14 +3,14 @@
 Plugin Name: Memberful - Membership Plugin
 Plugin URI: http://github.com/memberful/memberful-wp
 Description: Sell memberships and restrict access to content with WordPress and Memberful.
-Version: 1.76.0
+Version: 1.76.1
 Author: Memberful
 Author URI: http://memberful.com
 License: GPLv2 or later
  */
 
 if ( ! defined( 'MEMBERFUL_VERSION' ) )
-  define( 'MEMBERFUL_VERSION', '1.76.0' );
+  define( 'MEMBERFUL_VERSION', '1.76.1' );
 
 if ( ! defined( 'MEMBERFUL_PLUGIN_FILE' ) )
   define( 'MEMBERFUL_PLUGIN_FILE', __FILE__ );

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -2,9 +2,9 @@
 Contributors: drewstrojny, jakememberful, julianmemberful, lucasmemberful, patrikmemberful
 Tags: membership, subscriptions, paywall, stripe, recurring payments, memberful, oauth, oauth 2.0, members, recurring billing
 Requires at least: 3.6
-Tested up to: 6.7
-Requires PHP: 7.0
-Stable tag: 1.76.0
+Tested up to: 6.8.3
+Requires PHP: 7.4
+Stable tag: 1.76.1
 License: GPLv2 or later
 
 Sell memberships and restrict access to content with WordPress and Memberful.
@@ -110,6 +110,11 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 19. View membership information
 
 == Changelog ==
+
+= 1.76.1 =
+
+* Update WordPress compatibility to 6.8.3
+* Update minimum PHP requirement to 7.4
 
 = 1.76.0 =
 


### PR DESCRIPTION
Update version to 1.76.1, enhance WordPress compatibility to 6.8.3 and raise minimum PHP requirement to 7.4 in readme and main plugin file.