### PR TITLE
MR-7: Paywall Divider Block

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/block.json
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/block.json
@@ -4,7 +4,7 @@
   "name": "memberful/paywall-divider",
   "title": "Memberful Paywall Divider",
   "version": "1.0.0",
-  "description": "Marks where protected content starts for unauthorised visitors.",
+  "description": "Marks where protected content starts for unauthorized visitors.",
   "category": "memberful",
   "icon": "minus",
   "keywords": [

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/block.json
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/block.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+  "name": "memberful/paywall-divider",
+  "title": "Memberful Paywall Divider",
+  "version": "1.0.0",
+  "description": "Marks where protected content starts for unauthorised visitors.",
+  "category": "memberful",
+  "icon": "minus",
+  "keywords": [
+    "Memberful",
+    "Paywall",
+    "Design"
+  ],
+  "textdomain": "memberful",
+  "supports": {
+    "className": false,
+    "html": false,
+    "reusable": false,
+    "multiple": false,
+    "customClassName": false,
+    "visibility": false,
+    "renaming": false
+  },
+  "editorScript": "memberful-wp-block-editor"
+}

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/block.json
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
+  "apiVersion": 3,
   "name": "memberful/paywall-divider",
   "title": "Memberful Paywall Divider",
   "version": "1.0.0",

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/index.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/index.js
@@ -1,0 +1,26 @@
+import { registerBlockType } from "@wordpress/blocks";
+import { useBlockProps } from "@wordpress/block-editor";
+import { __ } from "@wordpress/i18n";
+import metadata from "./block.json";
+
+registerBlockType(metadata.name, {
+  edit: () => {
+    const blockProps = useBlockProps({
+      className: "memberful-paywall-divider",
+    });
+
+    return (
+      <div
+        {...blockProps}
+        style={{
+          borderTop: "2px dashed #8c8f94",
+          margin: "16px 0",
+          paddingTop: "8px",
+        }}
+      >
+        <strong>{__("Protected content below this line", "memberful")}</strong>
+      </div>
+    );
+  },
+  save: () => null,
+});

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/index.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/index.js
@@ -13,12 +13,24 @@ registerBlockType(metadata.name, {
       <div
         {...blockProps}
         style={{
-          borderTop: "2px dashed #8c8f94",
+          borderTop: "2px dashed currentColor",
           margin: "16px 0",
           paddingTop: "8px",
+          opacity: 0.6,
         }}
       >
         <strong>{__("Protected content below this line", "memberful")}</strong>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width="18"
+          height="18"
+          fill="currentColor"
+          style={{ marginLeft: "6px", verticalAlign: "middle" }}
+          aria-hidden="true"
+        >
+          <path d="M12 15.5l-6-6 1.41-1.41L12 12.67l4.59-4.58L18 9.5z" />
+        </svg>
       </div>
     );
   },

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/editor-scripts.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/editor-scripts.js
@@ -6,3 +6,4 @@
 
 // Block imports.
 import "./blocks/extensions";
+import "./blocks/paywall-divider";

--- a/wordpress/wp-content/plugins/memberful-wp/src/block-editor.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/block-editor.php
@@ -14,300 +14,299 @@
  */
 class Memberful_WP_Block_Editor {
 
-	/**
-	 * Class Instance
-	 *
-	 * @var Memberful_WP_Block_Editor
-	 */
-	private static $instance;
+  /**
+   * Class Instance
+   *
+   * @var Memberful_WP_Block_Editor
+   */
+  private static $instance;
 
-	/**
-	 * Get the class instance.
-	 *
-	 * @return Memberful_WP_Block_Editor The class instance.
-	 */
-	public static function get_instance() {
-		if ( ! isset( self::$instance ) ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
+  /**
+   * Get the class instance.
+   *
+   * @return Memberful_WP_Block_Editor The class instance.
+   */
+  public static function get_instance() {
+    if ( ! isset( self::$instance ) ) {
+      self::$instance = new self();
+    }
+    return self::$instance;
+  }
 
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		if ( function_exists( 'register_block_type' ) ) {
-			add_action( 'init', array( $this, 'register_blocks' ) );
-			add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
-			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
-			add_filter( 'register_block_type_args', array( $this, 'add_block_visibility_attributes' ), 10, 2 );
+  /**
+   * Constructor.
+   */
+  public function __construct() {
+    if ( function_exists( 'register_block_type' ) ) {
+      add_action( 'init', array( $this, 'register_blocks' ) );
+      add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
+      add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
+      add_filter( 'register_block_type_args', array( $this, 'add_block_visibility_attributes' ), 10, 2 );
 
-			add_action( 'render_block', array( $this, 'render_block' ), 10, 2 );
-		}
-	}
+      add_action( 'render_block', array( $this, 'render_block' ), 10, 2 );
+    }
+  }
 
-	/**
-	 * Get the blocks that are excluded from the block visibility controls.
-	 *
-	 * @since 1.77.0
-	 *
-	 * @return array The blocks that are excluded from the block visibility controls.
-	 */
-	public static function get_block_visibility_excluded_blocks() {
+  /**
+   * Get the blocks that are excluded from the block visibility controls.
+   *
+   * @since 1.77.0
+   *
+   * @return array The blocks that are excluded from the block visibility controls.
+   */
+  public static function get_block_visibility_excluded_blocks() {
 
-		$excluded_blocks = array(
-			'memberful/paywall-divider',
-		);
+    $excluded_blocks = array(
+      'memberful/paywall-divider',
+    );
 
-		/**
-		 * Filters the blocks that are excluded from the block visibility controls.
-		 *
-		 * @since 1.77.0
-		 *
-		 * @param array $block_visibility_excluded_blocks The blocks that are excluded from the block visibility controls.
-		 * @return array The blocks that are excluded from the block visibility controls.
-		*/
-		return apply_filters( 'memberful_wp_block_visibility_excluded_blocks', $excluded_blocks );
-	}
+    /**
+     * Filters the blocks that are excluded from the block visibility controls.
+     *
+     * @since 1.77.0
+     *
+     * @param array $block_visibility_excluded_blocks The blocks that are excluded from the block visibility controls.
+     * @return array The blocks that are excluded from the block visibility controls.
+    */
+    return apply_filters( 'memberful_wp_block_visibility_excluded_blocks', $excluded_blocks );
+  }
 
-	/**
-	 * Register Memberful block types.
-	 *
-	 * @since 1.78.1
-	 *
-	 * @return void
-	 */
-	public function register_blocks(): void {
-		$block_directory = MEMBERFUL_DIR . '/js/build/blocks/paywall-divider';
+  /**
+   * Register Memberful block types.
+   *
+   * @since 1.78.1
+   *
+   * @return void
+   */
+  public function register_blocks(): void {
+    $block_directory = MEMBERFUL_DIR . '/js/build/blocks/paywall-divider';
 
-		if ( ! file_exists( $block_directory . '/block.json' ) ) {
-			$block_directory = MEMBERFUL_DIR . '/js/src/blocks/paywall-divider';
-		}
+    if ( ! file_exists( $block_directory . '/block.json' ) ) {
+      $block_directory = MEMBERFUL_DIR . '/js/src/blocks/paywall-divider';
+    }
 
-		register_block_type(
-			$block_directory,
-			array(
-				'render_callback' => '__return_empty_string',
-        'autoRegister' => true,
-			)
-		);
-	}
+    register_block_type(
+      $block_directory,
+      array(
+        'render_callback' => '__return_empty_string',
+      )
+    );
+  }
 
-	/**
-	 * Register custom block categories for the block inserter.
-	 *
-	 * @since 1.78.1
-	 *
-	 * @param array $categories Existing block categories.
-	 * @return array Updated block categories.
-	 */
-	public function register_block_categories( $categories ) {
-		$memberful_category_exists = false;
+  /**
+   * Register custom block categories for the block inserter.
+   *
+   * @since 1.78.1
+   *
+   * @param array $categories Existing block categories.
+   * @return array Updated block categories.
+   */
+  public function register_block_categories( $categories ) {
+    $memberful_category_exists = false;
 
-		foreach ( $categories as $category ) {
-			if ( isset( $category['slug'] ) && 'memberful' === $category['slug'] ) {
-				$memberful_category_exists = true;
-				break;
-			}
-		}
+    foreach ( $categories as $category ) {
+      if ( isset( $category['slug'] ) && 'memberful' === $category['slug'] ) {
+        $memberful_category_exists = true;
+        break;
+      }
+    }
 
-		if ( $memberful_category_exists ) {
-			return $categories;
-		}
+    if ( $memberful_category_exists ) {
+      return $categories;
+    }
 
-		$categories[] = array(
-			'slug'  => 'memberful',
-			'title' => __( 'Memberful', 'memberful' ),
-			'icon'  => null,
-		);
+    $categories[] = array(
+      'slug'  => 'memberful',
+      'title' => __( 'Memberful', 'memberful' ),
+      'icon'  => null,
+    );
 
-		return $categories;
-	}
+    return $categories;
+  }
 
-	/**
-	 * Enqueue the block editor assets.
-	 *
-	 * @since 1.77.0
-	 *
-	 * @return void
-	 */
-	public function enqueue_assets(): void {
-		$block_editor_script      = MEMBERFUL_DIR . '/js/build/editor-scripts.asset.php';
-		$block_editor_script_info = file_exists( $block_editor_script )
-			? include $block_editor_script
-			: array(
-				'dependencies' => array(),
-				'version'      => MEMBERFUL_VERSION,
-			);
+  /**
+   * Enqueue the block editor assets.
+   *
+   * @since 1.77.0
+   *
+   * @return void
+   */
+  public function enqueue_assets(): void {
+    $block_editor_script      = MEMBERFUL_DIR . '/js/build/editor-scripts.asset.php';
+    $block_editor_script_info = file_exists( $block_editor_script )
+      ? include $block_editor_script
+      : array(
+        'dependencies' => array(),
+        'version'      => MEMBERFUL_VERSION,
+      );
 
-		wp_enqueue_script(
-			'memberful-wp-block-editor',
-			plugins_url( 'js/build/editor-scripts.js', MEMBERFUL_PLUGIN_FILE ),
-			$block_editor_script_info['dependencies'],
-			$block_editor_script_info['version']
-		);
-		wp_localize_script(
-			'memberful-wp-block-editor',
-			'memberful_wp_block_editor',
-			array(
-				'options'                          => memberful_wp_option_values(),
-				'block_visibility_excluded_blocks' => self::get_block_visibility_excluded_blocks(),
-			)
-		);
-	}
+    wp_enqueue_script(
+      'memberful-wp-block-editor',
+      plugins_url( 'js/build/editor-scripts.js', MEMBERFUL_PLUGIN_FILE ),
+      $block_editor_script_info['dependencies'],
+      $block_editor_script_info['version']
+    );
+    wp_localize_script(
+      'memberful-wp-block-editor',
+      'memberful_wp_block_editor',
+      array(
+        'options'                          => memberful_wp_option_values(),
+        'block_visibility_excluded_blocks' => self::get_block_visibility_excluded_blocks(),
+      )
+    );
+  }
 
-	/**
-	 * Add the block visibility attributes to registered blocks server-side.
-	 *
-	 * @since 1.77.0
-	 *
-	 * @param array  $args The block arguments.
-	 * @param string $name The block name.
-	 * @return array The block arguments.
-	 */
-	public function add_block_visibility_attributes( $args, $name ) {
-		// Skip for excluded blocks.
-		if ( in_array( $name, self::get_block_visibility_excluded_blocks(), true ) ) {
-			return $args;
-		}
+  /**
+   * Add the block visibility attributes to registered blocks server-side.
+   *
+   * @since 1.77.0
+   *
+   * @param array  $args The block arguments.
+   * @param string $name The block name.
+   * @return array The block arguments.
+   */
+  public function add_block_visibility_attributes( $args, $name ) {
+    // Skip for excluded blocks.
+    if ( in_array( $name, self::get_block_visibility_excluded_blocks(), true ) ) {
+      return $args;
+    }
 
-		$args['attributes']['memberful_visibility'] = array(
-			'type'    => 'string',
-			'enum'    => array( 'none', 'logged_in', 'specific' ),
-			'default' => 'none',
-		);
+    $args['attributes']['memberful_visibility'] = array(
+      'type'    => 'string',
+      'enum'    => array( 'none', 'logged_in', 'specific' ),
+      'default' => 'none',
+    );
 
-		$args['attributes']['memberful_visibility_hide'] = array(
-			'type'    => 'boolean',
-			'default' => false,
-		);
+    $args['attributes']['memberful_visibility_hide'] = array(
+      'type'    => 'boolean',
+      'default' => false,
+    );
 
-		$args['attributes']['memberful_visibility_plans'] = array(
-			'type'    => 'array',
-			'default' => array(),
-		);
+    $args['attributes']['memberful_visibility_plans'] = array(
+      'type'    => 'array',
+      'default' => array(),
+    );
 
-		return $args;
-	}
+    return $args;
+  }
 
-	/**
-	 * Conditionally render the block based on the block visibility conditions.
-	 *
-	 * @since 1.77.0
-	 *
-	 * @param string $block_content The block content.
-	 * @param array  $block The block.
-	 * @return string The block content.
-	 */
-	public function render_block( $block_content, $block ): string {
+  /**
+   * Conditionally render the block based on the block visibility conditions.
+   *
+   * @since 1.77.0
+   *
+   * @param string $block_content The block content.
+   * @param array  $block The block.
+   * @return string The block content.
+   */
+  public function render_block( $block_content, $block ): string {
 
-		$original_block_content = $block_content;
+    $original_block_content = $block_content;
 
-		// Skip if no visibility rule is set.
-		if ( empty( $block['attrs'] ) || empty( $block['attrs']['memberful_visibility'] ) ) {
-			return $block_content;
-		}
+    // Skip if no visibility rule is set.
+    if ( empty( $block['attrs'] ) || empty( $block['attrs']['memberful_visibility'] ) ) {
+      return $block_content;
+    }
 
-		// Handle the block visibility conditions.
-		switch ( $block['attrs']['memberful_visibility'] ) {
-			case 'logged_in':
-				$block_content = $this->all_members_visibility( $block['attrs'], $block_content );
-				break;
+    // Handle the block visibility conditions.
+    switch ( $block['attrs']['memberful_visibility'] ) {
+      case 'logged_in':
+        $block_content = $this->all_members_visibility( $block['attrs'], $block_content );
+        break;
 
-			case 'specific':
-				$block_content = $this->specific_plans_visibility( $block['attrs'], $block_content );
-				break;
+      case 'specific':
+        $block_content = $this->specific_plans_visibility( $block['attrs'], $block_content );
+        break;
 
-			default:
-				break;
-		}
+      default:
+        break;
+    }
 
-		/**
-		 * Filters the block content before it is rendered.
-		 *
-		 * This is run after the block visibility conditions have been applied.
-		 *
-		 * @since 1.77.0
-		 *
-		 * @param string $block_content The block content.
-		 * @param array $block The block.
-		 * @param string $original_block_content The original block content before the visibility conditions were applied.
-		 * @return string The block content.
-		 */
-		$block_content = apply_filters( 'memberful_wp_render_block', $block_content, $block, $original_block_content );
+    /**
+     * Filters the block content before it is rendered.
+     *
+     * This is run after the block visibility conditions have been applied.
+     *
+     * @since 1.77.0
+     *
+     * @param string $block_content The block content.
+     * @param array $block The block.
+     * @param string $original_block_content The original block content before the visibility conditions were applied.
+     * @return string The block content.
+     */
+    $block_content = apply_filters( 'memberful_wp_render_block', $block_content, $block, $original_block_content );
 
-		return $block_content;
-	}
+    return $block_content;
+  }
 
-	/**
-	 * All Members Visibility.
-	 *
-	 * Any logged in user will see the block.
-	 *
-	 * @since 1.77.0
-	 *
-	 * @param array $block_attributes The block data.
-	 * @param mixed $block_content The block content.
-	 * @return mixed Returns the new block content.
-	 */
-	public function all_members_visibility( $block_attributes, $block_content ) {
-		$is_logged_in = is_user_logged_in();
+  /**
+   * All Members Visibility.
+   *
+   * Any logged in user will see the block.
+   *
+   * @since 1.77.0
+   *
+   * @param array $block_attributes The block data.
+   * @param mixed $block_content The block content.
+   * @return mixed Returns the new block content.
+   */
+  public function all_members_visibility( $block_attributes, $block_content ) {
+    $is_logged_in = is_user_logged_in();
 
-		if ( $this->should_reverse_visibility_conditions( $block_attributes ) ) {
-			// Show to logged out users only.
-			return $is_logged_in ? '' : $block_content;
-		}
+    if ( $this->should_reverse_visibility_conditions( $block_attributes ) ) {
+      // Show to logged out users only.
+      return $is_logged_in ? '' : $block_content;
+    }
 
-		// Default: show to any logged‑in user only.
-		return $is_logged_in ? $block_content : '';
-	}
+    // Default: show to any logged‑in user only.
+    return $is_logged_in ? $block_content : '';
+  }
 
-	/**
-	 * Specific Plans Visibility.
-	 *
-	 * Members with the specific plans will see the block,
-	 * unless the visibility conditions are reversed or the user does not have any of the specific plans.
-	 *
-	 * @since 1.77.0
-	 *
-	 * @param array $block_attributes The block data.
-	 * @param mixed $block_content The block content.
-	 * @return mixed Returns the new block content.
-	 */
-	public function specific_plans_visibility( $block_attributes, $block_content ) {
-		// Logged out users will not see the block at all.
-		if ( ! is_user_logged_in() ) {
-			return '';
-		}
+  /**
+   * Specific Plans Visibility.
+   *
+   * Members with the specific plans will see the block,
+   * unless the visibility conditions are reversed or the user does not have any of the specific plans.
+   *
+   * @since 1.77.0
+   *
+   * @param array $block_attributes The block data.
+   * @param mixed $block_content The block content.
+   * @return mixed Returns the new block content.
+   */
+  public function specific_plans_visibility( $block_attributes, $block_content ) {
+    // Logged out users will not see the block at all.
+    if ( ! is_user_logged_in() ) {
+      return '';
+    }
 
-		$plans = $block_attributes['memberful_visibility_plans'] ?? array();
+    $plans = $block_attributes['memberful_visibility_plans'] ?? array();
 
-		// No plans configured - fall back to rendering the block unmodified.
-		if ( empty( $plans ) ) {
-			return $block_content;
-		}
+    // No plans configured - fall back to rendering the block unmodified.
+    if ( empty( $plans ) ) {
+      return $block_content;
+    }
 
-		// Hide the block if the user has any of the specific plans.
-		if ( $this->should_reverse_visibility_conditions( $block_attributes ) ) {
-			return memberful_wp_user_has_subscription_to_plans( wp_get_current_user()->ID, $plans ) ? '' : $block_content;
-		}
+    // Hide the block if the user has any of the specific plans.
+    if ( $this->should_reverse_visibility_conditions( $block_attributes ) ) {
+      return memberful_wp_user_has_subscription_to_plans( wp_get_current_user()->ID, $plans ) ? '' : $block_content;
+    }
 
-		// Show the block if the user has any of the specific plans.
-		return memberful_wp_user_has_subscription_to_plans( wp_get_current_user()->ID, $plans ) ? $block_content : '';
-	}
+    // Show the block if the user has any of the specific plans.
+    return memberful_wp_user_has_subscription_to_plans( wp_get_current_user()->ID, $plans ) ? $block_content : '';
+  }
 
-	/**
-	 * Should the visibility conditions be reversed?
-	 *
-	 * @since 1.77.0
-	 *
-	 * @param array $block_attributes The block data.
-	 * @return boolean Returns true if the visibility conditions should be reversed.
-	 */
-	public function should_reverse_visibility_conditions( $block_attributes ) {
-		return ! empty( $block_attributes['memberful_visibility_hide'] );
-	}
+  /**
+   * Should the visibility conditions be reversed?
+   *
+   * @since 1.77.0
+   *
+   * @param array $block_attributes The block data.
+   * @return boolean Returns true if the visibility conditions should be reversed.
+   */
+  public function should_reverse_visibility_conditions( $block_attributes ) {
+    return ! empty( $block_attributes['memberful_visibility_hide'] );
+  }
 }
 
 /**
@@ -328,5 +327,5 @@ Memberful_WP_Block_Editor::get_instance();
  * @return array The blocks that are excluded from the block visibility controls.
  */
 function memberful_wp_get_block_visibility_excluded_blocks() {
-	return Memberful_WP_Block_Editor::get_block_visibility_excluded_blocks();
+  return Memberful_WP_Block_Editor::get_block_visibility_excluded_blocks();
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/block-editor.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/block-editor.php
@@ -88,7 +88,7 @@ class Memberful_WP_Block_Editor {
     register_block_type(
       $block_directory,
       array(
-        'render_callback' => '__return_empty_string',
+        'render_callback' => 'memberful_wp_render_paywall_divider_block',
       )
     );
   }
@@ -328,4 +328,13 @@ Memberful_WP_Block_Editor::get_instance();
  */
 function memberful_wp_get_block_visibility_excluded_blocks() {
   return Memberful_WP_Block_Editor::get_block_visibility_excluded_blocks();
+}
+
+/**
+ * Render callback for the Memberful paywall divider block.
+ *
+ * @return string
+ */
+function memberful_wp_render_paywall_divider_block() {
+  return '<!-- memberful-paywall-divider -->';
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/block-editor.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/block-editor.php
@@ -38,6 +38,8 @@ class Memberful_WP_Block_Editor {
 	 */
 	public function __construct() {
 		if ( function_exists( 'register_block_type' ) ) {
+			add_action( 'init', array( $this, 'register_blocks' ) );
+			add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
 			add_filter( 'register_block_type_args', array( $this, 'add_block_visibility_attributes' ), 10, 2 );
 
@@ -54,7 +56,9 @@ class Memberful_WP_Block_Editor {
 	 */
 	public static function get_block_visibility_excluded_blocks() {
 
-		$excluded_blocks = array();
+		$excluded_blocks = array(
+			'memberful/paywall-divider',
+		);
 
 		/**
 		 * Filters the blocks that are excluded from the block visibility controls.
@@ -65,6 +69,60 @@ class Memberful_WP_Block_Editor {
 		 * @return array The blocks that are excluded from the block visibility controls.
 		*/
 		return apply_filters( 'memberful_wp_block_visibility_excluded_blocks', $excluded_blocks );
+	}
+
+	/**
+	 * Register Memberful block types.
+	 *
+	 * @since 1.78.1
+	 *
+	 * @return void
+	 */
+	public function register_blocks(): void {
+		$block_directory = MEMBERFUL_DIR . '/js/build/blocks/paywall-divider';
+
+		if ( ! file_exists( $block_directory . '/block.json' ) ) {
+			$block_directory = MEMBERFUL_DIR . '/js/src/blocks/paywall-divider';
+		}
+
+		register_block_type(
+			$block_directory,
+			array(
+				'render_callback' => '__return_empty_string',
+        'autoRegister' => true,
+			)
+		);
+	}
+
+	/**
+	 * Register custom block categories for the block inserter.
+	 *
+	 * @since 1.78.1
+	 *
+	 * @param array $categories Existing block categories.
+	 * @return array Updated block categories.
+	 */
+	public function register_block_categories( $categories ) {
+		$memberful_category_exists = false;
+
+		foreach ( $categories as $category ) {
+			if ( isset( $category['slug'] ) && 'memberful' === $category['slug'] ) {
+				$memberful_category_exists = true;
+				break;
+			}
+		}
+
+		if ( $memberful_category_exists ) {
+			return $categories;
+		}
+
+		$categories[] = array(
+			'slug'  => 'memberful',
+			'title' => __( 'Memberful', 'memberful' ),
+			'icon'  => null,
+		);
+
+		return $categories;
 	}
 
 	/**

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -2,6 +2,87 @@
 
 add_action( 'the_content', 'memberful_wp_protect_content', 100 );
 
+/**
+ * Split post content at the first paywall divider block.
+ *
+ * @param string $content Raw post content.
+ * @return array{
+ *   has_divider: bool,
+ *   content_above_divider: string,
+ *   content_below_divider: string
+ * }
+ */
+function memberful_wp_split_post_content_at_paywall_divider( $content ) {
+  $content = (string) $content;
+
+  if ( '' === $content ) {
+    return array(
+      'has_divider'            => false,
+      'content_above_divider'  => '',
+      'content_below_divider'  => '',
+    );
+  }
+
+  $divider_pattern = '/<!--\s+wp:memberful\/paywall-divider(?:\s+[^>]*)?\s*\/-->|<!--\s+wp:memberful\/paywall-divider(?:\s+[^>]*)?\s*-->\s*<!--\s+\/wp:memberful\/paywall-divider\s*-->/';
+  $content_parts   = preg_split( $divider_pattern, $content, 2 );
+
+  if ( ! is_array( $content_parts ) || 2 !== count( $content_parts ) ) {
+    return array(
+      'has_divider'            => false,
+      'content_above_divider'  => $content,
+      'content_below_divider'  => '',
+    );
+  }
+
+  return array(
+    'has_divider'            => true,
+    'content_above_divider'  => $content_parts[0],
+    'content_below_divider'  => $content_parts[1],
+  );
+}
+
+/**
+ * Render content using the standard `the_content` pipeline without recursion.
+ *
+ * @param string $content Content to render.
+ * @return string Rendered content.
+ */
+function memberful_wp_render_content_without_protection( $content ) {
+  if ( '' === trim( (string) $content ) ) {
+    return $content;
+  }
+
+  remove_action( 'the_content', 'memberful_wp_protect_content', 100 );
+  $rendered_content = apply_filters( 'the_content', $content );
+  add_action( 'the_content', 'memberful_wp_protect_content', 100 );
+
+  return $rendered_content;
+}
+
+/**
+ * Apply teaser wrapper and CSS for divider content when snippets are enabled.
+ *
+ * @param string $content Rendered content above the paywall divider.
+ * @return string Formatted teaser content.
+ */
+function memberful_wp_format_divider_teaser_content( $content ) {
+  if ( '' === trim( (string) $content ) ) {
+    return $content;
+  }
+
+  if ( ! get_option( 'memberful_use_global_snippets' ) ) {
+    return $content;
+  }
+
+  $wrapped_content = "<div class='memberful-global-teaser-content'>$content</div>";
+
+  if ( function_exists( 'memberful_get_teaser_css' ) && ! did_action( 'memberful_teaser_css' ) ) {
+    $wrapped_content .= apply_filters( 'memberful_teaser_css', memberful_get_teaser_css() );
+  }
+
+  return $wrapped_content;
+}
+
 function memberful_wp_protect_content( $content ) {
   global $post;
 
@@ -33,6 +114,22 @@ function memberful_wp_protect_content( $content ) {
     add_filter("rss_enclosure", "__return_empty_string");
 
     $memberful_marketing_content = memberful_marketing_content( $post->ID );
+
+    // Split the content at the paywall divider (if present).
+    $content_split = memberful_wp_split_post_content_at_paywall_divider( $post->post_content );
+
+    if ( $content_split['has_divider'] ) {
+      $rendered_content_above_divider = memberful_wp_render_content_without_protection( $content_split['content_above_divider'] );
+      $rendered_content_above_divider = memberful_wp_format_divider_teaser_content( $rendered_content_above_divider );
+      $rendered_marketing_content = apply_filters( 'memberful_wp_protect_content', $memberful_marketing_content );
+
+      if ( '' !== trim( (string) $rendered_marketing_content ) ) {
+        return $rendered_content_above_divider . $rendered_marketing_content;
+      }
+
+      return $rendered_content_above_divider;
+    }
+
     return apply_filters( 'memberful_wp_protect_content', $memberful_marketing_content );
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -76,7 +76,7 @@ function memberful_wp_format_divider_teaser_content( $content ) {
 
   $wrapped_content = "<div class='memberful-global-teaser-content'>$content</div>";
 
-  if ( function_exists( 'memberful_get_teaser_css' ) && ! did_action( 'memberful_teaser_css' ) ) {
+  if ( function_exists( 'memberful_get_teaser_css' ) && ! did_filter( 'memberful_teaser_css' ) ) {
     $wrapped_content .= apply_filters( 'memberful_teaser_css', memberful_get_teaser_css() );
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -3,9 +3,28 @@
 add_action( 'the_content', 'memberful_wp_protect_content', 100 );
 
 /**
- * Split post content at the first paywall divider block.
+ * Get the marker inserted by the paywall divider block.
  *
- * @param string $content Raw post content.
+ * @return string
+ */
+function memberful_wp_get_paywall_divider_marker() {
+  return '<!-- memberful-paywall-divider -->';
+}
+
+/**
+ * Remove the paywall divider marker from rendered content.
+ *
+ * @param string $content Rendered post content.
+ * @return string
+ */
+function memberful_wp_strip_paywall_divider_marker( $content ) {
+  return str_replace( memberful_wp_get_paywall_divider_marker(), '', (string) $content );
+}
+
+/**
+ * Split rendered post content at the first paywall divider marker.
+ *
+ * @param string $content Rendered post content.
  * @return array{
  *   has_divider: bool,
  *   content_above_divider: string,
@@ -23,8 +42,7 @@ function memberful_wp_split_post_content_at_paywall_divider( $content ) {
     );
   }
 
-  $divider_pattern = '/<!--\s+wp:memberful\/paywall-divider(?:\s+[^>]*)?\s*\/-->|<!--\s+wp:memberful\/paywall-divider(?:\s+[^>]*)?\s*-->\s*<!--\s+\/wp:memberful\/paywall-divider\s*-->/';
-  $content_parts   = preg_split( $divider_pattern, $content, 2 );
+  $content_parts = explode( memberful_wp_get_paywall_divider_marker(), $content, 2 );
 
   if ( ! is_array( $content_parts ) || 2 !== count( $content_parts ) ) {
     return array(
@@ -39,24 +57,6 @@ function memberful_wp_split_post_content_at_paywall_divider( $content ) {
     'content_above_divider'  => $content_parts[0],
     'content_below_divider'  => $content_parts[1],
   );
-}
-
-/**
- * Render content using the standard `the_content` pipeline without recursion.
- *
- * @param string $content Content to render.
- * @return string Rendered content.
- */
-function memberful_wp_render_content_without_protection( $content ) {
-  if ( '' === trim( (string) $content ) ) {
-    return $content;
-  }
-
-  remove_action( 'the_content', 'memberful_wp_protect_content', 100 );
-  $rendered_content = apply_filters( 'the_content', $content );
-  add_action( 'the_content', 'memberful_wp_protect_content', 100 );
-
-  return $rendered_content;
 }
 
 /**
@@ -86,19 +86,21 @@ function memberful_wp_format_divider_teaser_content( $content ) {
 function memberful_wp_protect_content( $content ) {
   global $post;
 
+  $content_split = memberful_wp_split_post_content_at_paywall_divider( $content );
+
   if ( !isset( $post ) ) {
     # Return the content since we're not in the loop if `$post` is `NULL`
     # Temporary fix for Elasticpress' syncing issue
-    return $content;
+    return memberful_wp_strip_paywall_divider_marker( $content );
   }
 
   if(doing_filter('memberful_wp_protect_content')){
-    return $content;
+    return memberful_wp_strip_paywall_divider_marker( $content );
   }
 
   // Do not filter content for admins
   if ( current_user_can( 'publish_posts' ) ) {
-    return $content;
+    return memberful_wp_strip_paywall_divider_marker( $content );
   }
 
   if ( ! memberful_can_user_access_post( wp_get_current_user()->ID, $post->ID ) ) {
@@ -115,25 +117,25 @@ function memberful_wp_protect_content( $content ) {
 
     $memberful_marketing_content = memberful_marketing_content( $post->ID );
 
-    // Split the content at the paywall divider (if present).
-    $content_split = memberful_wp_split_post_content_at_paywall_divider( $post->post_content );
-
     if ( $content_split['has_divider'] ) {
-      $rendered_content_above_divider = memberful_wp_render_content_without_protection( $content_split['content_above_divider'] );
-      $rendered_content_above_divider = memberful_wp_format_divider_teaser_content( $rendered_content_above_divider );
+      $content_above_divider = memberful_wp_format_divider_teaser_content( $content_split['content_above_divider'] );
       $rendered_marketing_content = apply_filters( 'memberful_wp_protect_content', $memberful_marketing_content );
 
       if ( '' !== trim( (string) $rendered_marketing_content ) ) {
-        return $rendered_content_above_divider . $rendered_marketing_content;
+        return $content_above_divider . $rendered_marketing_content;
       }
 
-      return $rendered_content_above_divider;
+      return $content_above_divider;
     }
 
     return apply_filters( 'memberful_wp_protect_content', $memberful_marketing_content );
   }
 
-  return $content;
+  if ( $content_split['has_divider'] ) {
+    return $content_split['content_above_divider'] . $content_split['content_below_divider'];
+  }
+
+  return memberful_wp_strip_paywall_divider_marker( $content );
 }
 
 add_filter( 'memberful_wp_protect_content','wptexturize');

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -44,12 +44,8 @@ function memberful_apply_global_snippets_content_filter( $memberful_marketing_co
 
   $wrapped_global_marketing_content = "<div class='memberful-global-marketing-content'>$replacement</div>";
 
-  if ( isset( $post ) ) {
-    $content_split = memberful_wp_split_post_content_at_paywall_divider( $post->post_content );
-
-    if ( $content_split['has_divider'] ) {
-      return $wrapped_global_marketing_content;
-    }
+  if ( isset( $post ) && has_block( 'memberful/paywall-divider', $post ) ) {
+    return $wrapped_global_marketing_content;
   }
 
   // Prevent endless loop trap
@@ -89,7 +85,7 @@ function memberful_apply_global_snippets_content_filter( $memberful_marketing_co
 
   $wrapped_teaser = "<div class='memberful-global-teaser-content'>$teaser</div>";
 
-  if ( $has_teaser && ! did_action( 'memberful_teaser_css' ) ) {
+  if ( $has_teaser && ! did_filter( 'memberful_teaser_css' ) ) {
     $wrapped_teaser .= apply_filters( 'memberful_teaser_css', memberful_get_teaser_css() );
   }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -44,6 +44,14 @@ function memberful_apply_global_snippets_content_filter( $memberful_marketing_co
 
   $wrapped_global_marketing_content = "<div class='memberful-global-marketing-content'>$replacement</div>";
 
+  if ( isset( $post ) ) {
+    $content_split = memberful_wp_split_post_content_at_paywall_divider( $post->post_content );
+
+    if ( $content_split['has_divider'] ) {
+      return $wrapped_global_marketing_content;
+    }
+  }
+
   // Prevent endless loop trap
   remove_action( 'the_content', 'memberful_wp_protect_content', -10 );
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -41,16 +41,19 @@
       <hr>
 
       <div id="global_marketing_snippet_options">
+      <label for="use_global_snippets_checkbox">
 
       <input id="use_global_snippets_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_snippets"
       <?php
       if ( $use_global_snippets ) :
         ?>
         checked="checked"<?php endif; ?>>
-        <span class="memberful-label__text--multiline"><strong>Automatically pull an excerpt from each post.</strong>
+        <small class="memberful-label__text--multiline"><strong>Automatically pull an excerpt from each post.</strong>
           <?php echo esc_html( ' Memberful will pull the first two paragraphs from each protected post to use as marketing content for logged out visitors.'
           . ' This feature requires <p> tags in your posts to detect which content to use.'
           . ' If a post contains a Memberful Paywall Divider block, all content above the divider will be shown instead of the excerpt.' ); ?>
+        </small>
+      </label>
       </div>
 
     </div>

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -9,7 +9,7 @@
     <h3><?php _e( 'Global marketing content', 'memberful' ); ?></h3>
     <p>
       <label for="use_global_marketing_checkbox">
-      <input id="use_global_marketing_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_marketing" 
+      <input id="use_global_marketing_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_marketing"
       <?php
       if ( $use_global_marketing ) :
         ?>
@@ -21,7 +21,7 @@
     </p>
     <div id="global_marketing_options" data-depends-on="use_global_marketing_checkbox" data-depends-value="1">
       <label for="global_marketing_override_radio_true">
-      <input id="global_marketing_override_radio_true" type="radio" name="memberful_global_marketing_override" value="1" 
+      <input id="global_marketing_override_radio_true" type="radio" name="memberful_global_marketing_override" value="1"
       <?php
       if ( $global_marketing_override ) {
         echo 'checked="checked"';}
@@ -39,17 +39,18 @@
       Only use the global marketing content when other content doesn't exist.
       </label>
       <hr>
-  
+
       <div id="global_marketing_snippet_options">
 
-      <input id="use_global_snippets_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_snippets" 
+      <input id="use_global_snippets_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_snippets"
       <?php
       if ( $use_global_snippets ) :
         ?>
         checked="checked"<?php endif; ?>>
         <span class="memberful-label__text--multiline"><strong>Automatically pull an excerpt from each post.</strong>
-          <?php echo esc_html(' Memberful will pull the first two paragraphs from each protected post to use as marketing content for logged out visitors.'
-          .' This feature requires <p> tags in your posts to detect which content to use.');?>
+          <?php echo esc_html( ' Memberful will pull the first two paragraphs from each protected post to use as marketing content for logged out visitors.'
+          . ' This feature requires <p> tags in your posts to detect which content to use.'
+          . ' If a post contains a Memberful Paywall Divider block, all content above the divider will be shown instead of the excerpt.' ); ?>
       </div>
 
     </div>


### PR DESCRIPTION
**New Features**

- Added a Paywall Divider block to the editor that marks protected-content boundaries; content above the divider is shown as a preview to unauthorised visitors while content below remains protected.
- Editor now includes a Memberful inserter category for easy access to the block.

**Behaviour**

- Teaser and global marketing logic updated so posts with a divider render only the above-divider preview and adjusted settings text reflects this.