### PR TITLE
Bump minimum WordPress version from 3.6 to 6.3

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -1,7 +1,7 @@
 === Memberful - Membership Plugin ===
 Contributors: drewstrojny, jakememberful, julianmemberful, lucasmemberful, patrikmemberful
 Tags: membership, subscriptions, paywall, stripe, recurring payments, memberful, oauth, oauth 2.0, members, recurring billing
-Requires at least: 3.6
+Requires at least: 6.3
 Tested up to: 6.9.1
 Requires PHP: 7.4
 Stable tag: 1.78.0


### PR DESCRIPTION
The plugin already uses APIs requiring much higher versions (e.g. `get_term_meta`/`update_term_meta` from WP 4.4, `do_blocks` from WP 5.0). Upcoming block features also rely on `register_block_type` with directory paths and `block_categories_all` (WP 5.8) and block.json apiVersion 3 (WP 6.3).