### PR TITLE
Build JS as part of the release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -56,6 +56,11 @@ ask_for_release_confirmation() {
   fi
 }
 
+build_js() {
+  echo "Building plugin JS in $PLUGIN_DIR"
+  (cd "$PLUGIN_DIR" && npm ci && npm run build)
+}
+
 push_to_wordpress_svn() {
   echo "Creating local copy of SVN repo in $SVN_LOCAL_PATH"
   svn co $SVN_URL $SVN_LOCAL_PATH
@@ -124,6 +129,7 @@ ask_for_release_confirmation
 if [ "$1" == "--assets" ]; then
   push_assets_to_wordpress_svn
 else
+  build_js
   push_to_wordpress_svn
 fi
 


### PR DESCRIPTION
The plugin's JS lives in js/build/, which is gitignored and not tracked in git. release.sh only rsyncs the plugin dir to SVN, so releases relied on whoever ran the script having built the JS locally first. If they hadn't, stale or missing JS would ship.

Add a build_js step that runs `npm ci && npm run build` before pushing to SVN trunk, so the built JS is always fresh in the release artifact. Named build_js rather than build_assets to avoid confusion with push_assets_to_wordpress_svn, which ships the WordPress.org listing artwork (banners/icons/screenshots).