### PR TITLE
Disable Raptive video players on mobile for members

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -115,6 +115,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 = unreleased =
 
 * Add an optional banner notifying members of expiring or expired memberships
+* Disable Raptive video players on mobile devices for members
 
 = 1.79.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/contrib/ad-providers/raptive-ads.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/contrib/ad-providers/raptive-ads.php
@@ -39,6 +39,27 @@ class Memberful_Wp_Integration_Ad_Provider_Raptive extends Memberful_Wp_Integrat
 
   public function disable_ads_for_user( $user_id ) {
     add_filter( 'body_class', array( $this, 'disable_ads_body_class' ) );
+    add_action( 'wp_head', array( $this, 'disable_video_player' ), 99 );
+  }
+
+  /**
+   * Signal to Raptive's ad script that video players are disabled.
+   *
+   * The adthrive-disable-video body class suppresses video on desktop, but the
+   * mobile sticky playlist player keys off the videoDisabledFromPlugin flag that
+   * Raptive's own per-page disable sets. Raptive derives that flag from post meta,
+   * not from filter-added body classes, so our body class alone does not trigger
+   * it. We replicate the flag here.
+   *
+   * Printed late on wp_head (priority 99) so it runs after Raptive defines
+   * window.adthriveCLS (priority 1) regardless of Raptive's priority, but still
+   * before the async ads.min.js executes. Merges rather than overwrites so the
+   * existing config is preserved.
+   *
+   * @see insertion-includes.php in the Raptive Ads (AdThrive) plugin.
+   */
+  public function disable_video_player() {
+    echo "<script>window.adthriveCLS = window.adthriveCLS || {}; window.adthriveCLS.videoDisabledFromPlugin = true;</script>\n";
   }
 
   /**


### PR DESCRIPTION
The adthrive-disable-all/adthrive-disable-video body classes suppress display ads and desktop video, but Raptive's mobile sticky playlist player kept showing for logged-in members.

Raptive's own per-page disable also emits
window.adthriveCLS.videoDisabledFromPlugin = true, derived from post meta rather than the rendered body classes, so a class added via the body_class filter never triggers it. The mobile sticky player appears to key off that flag, so we replicate it via a wp_head script. It runs late (priority 99) so it lands after Raptive defines window.adthriveCLS (priority 1) regardless of Raptive's priority, but still before the async ads.min.js executes; it merges rather than overwrites the config.

Experimental: not yet confirmed by Raptive or verified on a logged-in mobile session against a live Raptive site.

https://app.basecamp.com/3293071/buckets/5610905/card_tables/cards/9966430282#__recording_9966430471