### PR TITLE
Improve the debug tool

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -115,6 +115,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 = unreleased =
 
 * Add the `memberful_subscriptions_link` shortcode for linking to the subscriptions page
+* Improve the debug tool
 
 = 1.80.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -246,9 +246,9 @@ function memberful_wp_debug( $is_endpoint = FALSE ) {
   $error_log = memberful_wp_redact_secrets( $error_log, $secrets, $masks );
 
   $lookup_inputs = array(
-    'email'      => isset( $_GET['lookup_email'] ) ? trim( $_GET['lookup_email'] ) : '',
-    'member_id'  => isset( $_GET['lookup_member_id'] ) ? intval( $_GET['lookup_member_id'] ) : 0,
-    'wp_user_id' => isset( $_GET['lookup_wp_user_id'] ) ? intval( $_GET['lookup_wp_user_id'] ) : 0,
+    'email'      => isset( $_GET['member_email'] ) ? trim( $_GET['member_email'] ) : '',
+    'member_id'  => isset( $_GET['member_id'] ) ? intval( $_GET['member_id'] ) : 0,
+    'wp_user_id' => isset( $_GET['wp_user_id'] ) ? intval( $_GET['wp_user_id'] ) : 0,
   );
 
   $lookup = NULL;

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -190,7 +190,25 @@ function _memberful_wp_debug_all_post_meta() {
   return $meta;
 }
 
-function memberful_wp_debug() {
+function memberful_wp_mask_secret( $value ) {
+  $value = (string) $value;
+
+  return $value === '' ? '' : '****'.substr( $value, -4 );
+}
+
+function memberful_wp_redact_secrets( $data, array $search, array $replace ) {
+  if ( empty( $search ) )
+    return $data;
+
+  if ( is_array( $data ) )
+    return array_map( function ( $item ) use ( $search, $replace ) {
+      return memberful_wp_redact_secrets( $item, $search, $replace );
+    }, $data );
+
+  return is_string( $data ) ? str_replace( $search, $replace, $data ) : $data;
+}
+
+function memberful_wp_debug( $is_endpoint = FALSE ) {
   global $wp_version;
 
   if ( ! function_exists( 'get_plugins' ) ) {
@@ -200,13 +218,11 @@ function memberful_wp_debug() {
   $mapping_stats = new Memberful_User_Map_Stats(Memberful_User_Mapping_Repository::table());
   $counts = count_users();
 
-  $mapping_records       = $mapping_stats->mapping_records();
   $total_mapping_records = $mapping_stats->count_mapping_records();
-  $unmapped_users        = $mapping_stats->unmapped_users();
+  $total_mapped_users    = $mapping_stats->count_mapped_users();
 
   $total_users           = $counts['total_users'];
-  $total_unmapped_users  = count($unmapped_users);
-  $total_mapped_users    = $total_users - $total_unmapped_users;
+  $total_unmapped_users  = max( 0, $total_users - $total_mapped_users );
   $config                = memberful_wp_option_values();
   $acl_for_all_posts     = _memberful_wp_debug_all_post_meta();
   $plugins               = get_plugins();
@@ -214,24 +230,163 @@ function memberful_wp_debug() {
 
   unset( $config['memberful_error_log'] );
 
+  // Connection credentials are shown masked to their last four characters, both
+  // in the config and in the error log, where they appear inside request URLs.
+  $secrets = array();
+  $masks   = array();
+  foreach ( memberful_wp_connection_options() as $option ) {
+    if ( empty( $config[$option] ) )
+      continue;
+
+    $secrets[]       = $config[$option];
+    $masks[]         = memberful_wp_mask_secret( $config[$option] );
+    $config[$option] = memberful_wp_mask_secret( $config[$option] );
+  }
+
+  $error_log = memberful_wp_redact_secrets( $error_log, $secrets, $masks );
+
+  $lookup_inputs = array(
+    'email'      => isset( $_GET['lookup_email'] ) ? trim( $_GET['lookup_email'] ) : '',
+    'member_id'  => isset( $_GET['lookup_member_id'] ) ? intval( $_GET['lookup_member_id'] ) : 0,
+    'wp_user_id' => isset( $_GET['lookup_wp_user_id'] ) ? intval( $_GET['lookup_wp_user_id'] ) : 0,
+  );
+
+  $lookup = NULL;
+
+  if ( $lookup_inputs['email'] !== '' || $lookup_inputs['member_id'] > 0 || $lookup_inputs['wp_user_id'] > 0 ) {
+    $lookup = memberful_wp_debug_lookup(
+      $lookup_inputs['email'],
+      $lookup_inputs['member_id'],
+      $lookup_inputs['wp_user_id']
+    );
+  }
+
   memberful_wp_render(
     'debug',
     compact(
-      'unmapped_users',
       'total_users',
       'total_unmapped_users',
       'total_mapped_users',
       'total_mapping_records',
-      'mapping_records',
       'config',
       'acl_for_all_posts',
       'wp_version',
       'plugins',
-      'error_log'
+      'error_log',
+      'lookup_inputs',
+      'lookup',
+      'is_endpoint'
     )
   );
 }
 
+/**
+ * Resolves each supplied identifier (email, member_id, wp_user_id) independently
+ * into a "subject" describing a WP user and/or mapping row.
+ */
+function memberful_wp_debug_lookup( $email, $member_id, $wp_user_id ) {
+  $subjects = array();
+
+  if ( $email !== '' ) {
+    $users = get_users( array( 'search' => $email, 'search_columns' => array( 'user_email' ) ) );
+
+    if ( empty( $users ) ) {
+      $subjects[] = array( 'source' => "email: $email", 'flags' => array( 'No WP account with this email' ) );
+    } else {
+      $duplicate = count( $users ) > 1;
+
+      foreach ( $users as $user ) {
+        $subject = _memberful_wp_debug_subject_for_user( $user );
+        $subject['source'] = "email: $email";
+
+        if ( $duplicate )
+          $subject['flags'][] = 'Duplicate accounts share this email ('.count( $users ).')';
+
+        $subjects[] = $subject;
+      }
+    }
+  }
+
+  if ( $wp_user_id > 0 ) {
+    $user    = get_user_by( 'id', $wp_user_id );
+    $mapping = Memberful_User_Mapping_Repository::find_by_wp_user_id( $wp_user_id );
+
+    if ( $user ) {
+      $subject = _memberful_wp_debug_subject_for_user( $user, $mapping );
+    } elseif ( $mapping ) {
+      $subject = _memberful_wp_debug_subject_for_mapping( $mapping );
+    } else {
+      $subject = array( 'flags' => array( 'No WP user and no mapping for this ID' ) );
+    }
+
+    $subject['source'] = "wp_user_id: $wp_user_id";
+    $subjects[] = $subject;
+  }
+
+  if ( $member_id > 0 ) {
+    $mapping = Memberful_User_Mapping_Repository::find_by_member_id( $member_id );
+
+    if ( ! $mapping ) {
+      $subject = array( 'flags' => array( 'Member unknown locally (no mapping row)' ) );
+    } else {
+      $subject = _memberful_wp_debug_subject_for_mapping( $mapping );
+    }
+
+    $subject['source'] = "member_id: $member_id";
+    $subjects[] = $subject;
+  }
+
+  return $subjects;
+}
+
+function _memberful_wp_debug_subject_for_mapping( $mapping ) {
+  $user = ( $mapping->wp_user_id > 0 ) ? get_user_by( 'id', $mapping->wp_user_id ) : FALSE;
+
+  if ( $user )
+    return _memberful_wp_debug_subject_for_user( $user, $mapping );
+
+  $subject = _memberful_wp_debug_mapping_details( $mapping );
+
+  if ( empty( $mapping->wp_user_id ) )
+    $subject['flags'][] = 'Member not mapped to any WP user';
+  else
+    $subject['flags'][] = 'Orphaned mapping: WP user '.$mapping->wp_user_id.' no longer exists';
+
+  return $subject;
+}
+
+function _memberful_wp_debug_subject_for_user( $user, $mapping = NULL ) {
+  if ( $mapping === NULL )
+    $mapping = Memberful_User_Mapping_Repository::find_by_wp_user_id( $user->ID );
+
+  $subject = array(
+    'wp_user_id'   => $user->ID,
+    'user_login'   => $user->user_login,
+    'user_email'   => $user->user_email,
+    'display_name' => $user->display_name,
+    'registered'   => $user->user_registered,
+    'roles'        => $user->roles,
+    'flags'        => array(),
+  );
+
+  if ( $mapping ) {
+    $subject = array_merge( $subject, _memberful_wp_debug_mapping_details( $mapping ) );
+  } else {
+    $subject['member_id'] = NULL;
+    $subject['flags'][]   = 'Unmapped user';
+  }
+
+  return $subject;
+}
+
+function _memberful_wp_debug_mapping_details( $mapping ) {
+  return array(
+    'member_id'         => $mapping->member_id,
+    'last_sync_at'      => empty( $mapping->last_sync_at ) ? 'never' : date( 'r', $mapping->last_sync_at ),
+    'has_refresh_token' => ! empty( $mapping->refresh_token ),
+    'flags'             => empty( $mapping->refresh_token ) ? array( 'No refresh token' ) : array(),
+  );
+}
 
 /**
  * Displays the memberful options page

--- a/wordpress/wp-content/plugins/memberful-wp/src/endpoints/debug.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/endpoints/debug.php
@@ -26,7 +26,7 @@ class Memberful_Wp_Endpoint_Debug implements Memberful_Wp_Endpoint {
 
   public function process() {
     ob_start();
-    memberful_wp_debug();
+    memberful_wp_debug( TRUE );
     print html_entity_decode( strip_tags( ob_get_clean() ), ENT_QUOTES );
     exit;
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map.php
@@ -266,6 +266,20 @@ class Memberful_User_Mapping_Repository {
     );
   }
 
+  static public function find_by_member_id( $member_id ) {
+    global $wpdb;
+
+    return $wpdb->get_row( $wpdb->prepare(
+      'SELECT * FROM '.self::table().' WHERE member_id = %d', $member_id ) );
+  }
+
+  static public function find_by_wp_user_id( $wp_user_id ) {
+    global $wpdb;
+
+    return $wpdb->get_row( $wpdb->prepare(
+      'SELECT * FROM '.self::table().' WHERE wp_user_id = %d', $wp_user_id ) );
+  }
+
 
   /**
    * Attempts to find the ID of the user who the specified member maps to in

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map_stats.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map_stats.php
@@ -21,8 +21,7 @@ class Memberful_User_Map_Stats {
 
     return $wpdb->get_var(
       'SELECT COUNT(DISTINCT `mapping`.`wp_user_id`) FROM '.$this->table.' AS `mapping` '.
-      'INNER JOIN '.$wpdb->users.' AS `users` ON `users`.`ID` = `mapping`.`wp_user_id` '.
-      'WHERE `mapping`.`wp_user_id` > 0'
+      'INNER JOIN '.$wpdb->users.' AS `users` ON `users`.`ID` = `mapping`.`wp_user_id`'
     );
   }
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/map_stats.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/map_stats.php
@@ -8,30 +8,21 @@ class Memberful_User_Map_Stats {
     $this->table = $table_name;
   }
 
-  public function unmapped_users() {
-    global $wpdb;
-
-    $query = 'SELECT `mapping`.`wp_user_id` FROM '.$this->table.' AS `mapping`';
-
-    $mapped_users = array_filter( $wpdb->get_col($query) );
-
-    $query = 'SELECT users.* FROM '.$wpdb->users.' AS `users`';
-
-    if( !empty( $mapped_users ) )
-      $query .= ' WHERE ID NOT IN('.implode(',', $mapped_users).')';
-
-    return $wpdb->get_results($query);
-  }
-
   public function count_mapping_records() {
     global $wpdb;
 
     return $wpdb->get_var('SELECT COUNT(*) FROM '.$this->table);
   }
 
-  public function mapping_records() {
+  // Joins against wp_users (and counts distinct ids) so orphaned and duplicate
+  // mappings don't inflate the figure beyond the number of real mapped users.
+  public function count_mapped_users() {
     global $wpdb;
 
-    return $wpdb->get_results('SELECT * FROM '.$this->table);
+    return $wpdb->get_var(
+      'SELECT COUNT(DISTINCT `mapping`.`wp_user_id`) FROM '.$this->table.' AS `mapping` '.
+      'INNER JOIN '.$wpdb->users.' AS `users` ON `users`.`ID` = `mapping`.`wp_user_id` '.
+      'WHERE `mapping`.`wp_user_id` > 0'
+    );
   }
 }

--- a/wordpress/wp-content/plugins/memberful-wp/views/debug.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/debug.php
@@ -1,5 +1,47 @@
-<h2><?php _e( 'Memberful debug information', 'memberful' ) ?></h2>
+<?php
+$lookup_done   = isset( $lookup ) && $lookup !== NULL;
+$requested_tab = isset( $_GET['debug_tab'] ) ? strtolower( $_GET['debug_tab'] ) : '';
 
+// Pick the active section. A lookup request always selects the lookup section.
+// In the HTML UI we fall back to system info; over the endpoint there are no
+// tabs, so we fall back to a usage page documenting the tabs and lookup params.
+if ( $lookup_done || $requested_tab === 'lookup' )
+  $active_tab = 'lookup';
+elseif ( $requested_tab === 'system' || ! $is_endpoint )
+  $active_tab = 'system';
+else
+  $active_tab = 'usage';
+
+$base_url = admin_url( 'options-general.php?page=memberful_options&subpage=debug' );
+?>
+<?php if ( ! $is_endpoint ): ?>
+<div class="wrap">
+<h1><?php _e( 'Memberful debug', 'memberful' ); ?></h1>
+<h2 class="nav-tab-wrapper">
+  <a href="<?php echo esc_url( $base_url.'&debug_tab=system' ); ?>" class="nav-tab<?php echo $active_tab === 'system' ? ' nav-tab-active' : ''; ?>"><?php _e( 'System info', 'memberful' ); ?></a>
+  <a href="<?php echo esc_url( $base_url.'&debug_tab=lookup' ); ?>" class="nav-tab<?php echo $active_tab === 'lookup' ? ' nav-tab-active' : ''; ?>"><?php _e( 'Member / user lookup', 'memberful' ); ?></a>
+</h2>
+<?php endif; ?>
+
+<?php if ( $is_endpoint && $active_tab === 'usage' ): ?>
+<h2><?php _e( 'Memberful debug endpoint', 'memberful' ) ?></h2>
+<pre><code style="display:block;">
+Add a "debug_tab" parameter to choose what to render:
+
+  debug_tab=system   System info: WordPress, plugins, stats, config, ACL, error log
+  debug_tab=lookup   Member / user lookup
+
+For a lookup, pass one or more of these parameters (debug_tab=lookup is
+implied whenever any of them are present):
+
+  lookup_email       Look up by email address
+  lookup_member_id   Look up by Memberful member ID
+  lookup_wp_user_id  Look up by WordPress user ID
+</code></pre>
+<?php endif; ?>
+
+<?php if ( $active_tab === 'system' ): ?>
+<?php if ( $is_endpoint ): ?><h2><?php _e( 'Memberful debug information', 'memberful' ) ?></h2><?php endif; ?>
 <pre><code style="display:block;">
 Generated on: <?php echo date("Y-m-d H:i:s O"); ?>
 
@@ -39,34 +81,92 @@ Total unmapped users: <?php echo intval($total_unmapped_users); ?>
 
 # ACL
 <?php foreach($acl_for_all_posts as $post_id => $meta): ?>
-<?php echo str_pad(intval($post_id).':', 4); ?> <?php var_export($meta); ?>
+<?php echo str_pad(intval($post_id).':', 4); ?> <?php echo esc_html( var_export($meta, true) ); ?>
 
 <?php endforeach; ?>
 
-# Mappings
+# Error Log
+<?php foreach ( $error_log as $entry ):
+  $entry = (array) $entry;
+  $date  = isset( $entry['date'] ) ? $entry['date'] : '';
+  unset( $entry['date'] );
 
-<?php if ( $total_unmapped_users > 0 ): ?>
-Unmapped users:
-<?php echo str_pad('WP ID', 6), ' ', str_pad('Email', 30), ' ', 'Date registered' ?>
-<?php foreach($unmapped_users as $unmapped_user): ?>
+  echo "\n===== ".esc_html( $date )." =====\n";
 
-<?php echo str_pad(intval($unmapped_user->ID), 6) ?> <?php echo str_pad(sanitize_email($unmapped_user->user_email), 30) ?> <?php echo $unmapped_user->user_registered; ?>
-<?php endforeach; ?>
-
-<?php endif; ?>
-
-<?php if ( ! empty( $mapping_records ) ): ?>
-Mapping records:
-<?php echo str_pad('WP ID', 7), ' ', str_pad('Mem id', 7), ' ', str_pad('Last sync at', 32), ' ', str_pad('Refresh token', 32) ?>
-<?php foreach($mapping_records as $record): ?>
-
-<?php echo str_pad(intval($record->wp_user_id), 7), ' ', str_pad(intval($record->member_id), 7), ' ', str_pad(date('r', $record->last_sync_at), 32), ' ', str_pad($record->refresh_token, 32); ?>
-<?php endforeach; ?>
-<?php endif; ?>
-
-Error Log:
-<?php var_export($error_log); ?>
+  foreach ( $entry as $key => $value ) {
+    $printable = ( is_scalar( $value ) || is_null( $value ) ) ? (string) $value : var_export( $value, true );
+    echo esc_html( $key ).": ".esc_html( $printable )."\n";
+  }
+endforeach; ?>
 
 </code>
 </pre>
+<?php endif; ?>
 
+<?php if ( $active_tab === 'lookup' ): ?>
+<?php if ( $is_endpoint ): ?><h2><?php _e( 'Member / user lookup', 'memberful' ) ?></h2><?php endif; ?>
+<?php if ( ! $is_endpoint ): ?>
+<form method="get">
+  <input type="hidden" name="page" value="memberful_options" />
+  <input type="hidden" name="subpage" value="debug" />
+  <input type="hidden" name="debug_tab" value="lookup" />
+  <table class="form-table" role="presentation">
+    <tr>
+      <th scope="row"><label for="memberful-lookup-email"><?php _e( 'Email', 'memberful' ); ?></label></th>
+      <td><input type="text" id="memberful-lookup-email" class="regular-text" name="lookup_email" value="<?php echo esc_attr( $lookup_inputs['email'] ); ?>" /></td>
+    </tr>
+    <tr>
+      <th scope="row"><label for="memberful-lookup-member-id"><?php _e( 'Member ID', 'memberful' ); ?></label></th>
+      <td><input type="text" id="memberful-lookup-member-id" class="regular-text" name="lookup_member_id" value="<?php echo $lookup_inputs['member_id'] > 0 ? intval( $lookup_inputs['member_id'] ) : ''; ?>" /></td>
+    </tr>
+    <tr>
+      <th scope="row"><label for="memberful-lookup-wp-user-id"><?php _e( 'WP user ID', 'memberful' ); ?></label></th>
+      <td><input type="text" id="memberful-lookup-wp-user-id" class="regular-text" name="lookup_wp_user_id" value="<?php echo $lookup_inputs['wp_user_id'] > 0 ? intval( $lookup_inputs['wp_user_id'] ) : ''; ?>" /></td>
+    </tr>
+  </table>
+  <p class="submit"><button type="submit" class="button button-primary"><?php _e( 'Look up', 'memberful' ); ?></button></p>
+</form>
+<?php endif; ?>
+
+<?php if ( $lookup_done ): ?>
+<pre><code style="display:block;">
+<?php if ( empty( $lookup ) ): ?>
+No records found.
+<?php else: ?>
+<?php foreach( $lookup as $subject ):
+  echo "--- ".esc_html( $subject['source'] )." ---\n";
+
+  if ( isset( $subject['wp_user_id'] ) ) {
+    echo "WP user ID:     ".intval( $subject['wp_user_id'] )."\n";
+    echo "Login:          ".esc_html( $subject['user_login'] )."\n";
+    echo "Email:          ".esc_html( $subject['user_email'] )."\n";
+    echo "Display name:   ".esc_html( $subject['display_name'] )."\n";
+    echo "Registered:     ".esc_html( $subject['registered'] )."\n";
+    echo "Roles:          ".esc_html( implode( ', ', (array) $subject['roles'] ) )."\n";
+  }
+
+  if ( isset( $subject['member_id'] ) && $subject['member_id'] !== NULL ) {
+    echo "Member ID:      ".intval( $subject['member_id'] )."\n";
+    echo "Last sync at:   ".esc_html( $subject['last_sync_at'] )."\n";
+    echo "Refresh token:  ".( $subject['has_refresh_token'] ? 'present' : 'missing' )."\n";
+  }
+
+  if ( ! empty( $subject['flags'] ) )
+    echo "Flags:          ".esc_html( implode( '; ', $subject['flags'] ) )."\n";
+
+  echo "\n";
+endforeach; ?>
+<?php endif; ?>
+</code>
+</pre>
+<?php elseif ( $is_endpoint ): ?>
+<pre><code style="display:block;">
+No lookup parameters supplied. Pass one or more of: lookup_email,
+lookup_member_id, lookup_wp_user_id.
+</code></pre>
+<?php endif; ?>
+<?php endif; ?>
+
+<?php if ( ! $is_endpoint ): ?>
+</div>
+<?php endif; ?>

--- a/wordpress/wp-content/plugins/memberful-wp/views/debug.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/debug.php
@@ -34,9 +34,9 @@ Add a "debug_tab" parameter to choose what to render:
 For a lookup, pass one or more of these parameters (debug_tab=lookup is
 implied whenever any of them are present):
 
-  lookup_email       Look up by email address
-  lookup_member_id   Look up by Memberful member ID
-  lookup_wp_user_id  Look up by WordPress user ID
+  member_email       Look up by email address
+  member_id          Look up by Memberful member ID
+  wp_user_id         Look up by WordPress user ID
 </code></pre>
 <?php endif; ?>
 
@@ -113,15 +113,15 @@ endforeach; ?>
   <table class="form-table" role="presentation">
     <tr>
       <th scope="row"><label for="memberful-lookup-email"><?php _e( 'Email', 'memberful' ); ?></label></th>
-      <td><input type="text" id="memberful-lookup-email" class="regular-text" name="lookup_email" value="<?php echo esc_attr( $lookup_inputs['email'] ); ?>" /></td>
+      <td><input type="text" id="memberful-lookup-email" class="regular-text" name="member_email" value="<?php echo esc_attr( $lookup_inputs['email'] ); ?>" /></td>
     </tr>
     <tr>
       <th scope="row"><label for="memberful-lookup-member-id"><?php _e( 'Member ID', 'memberful' ); ?></label></th>
-      <td><input type="text" id="memberful-lookup-member-id" class="regular-text" name="lookup_member_id" value="<?php echo $lookup_inputs['member_id'] > 0 ? intval( $lookup_inputs['member_id'] ) : ''; ?>" /></td>
+      <td><input type="text" id="memberful-lookup-member-id" class="regular-text" name="member_id" value="<?php echo $lookup_inputs['member_id'] > 0 ? intval( $lookup_inputs['member_id'] ) : ''; ?>" /></td>
     </tr>
     <tr>
       <th scope="row"><label for="memberful-lookup-wp-user-id"><?php _e( 'WP user ID', 'memberful' ); ?></label></th>
-      <td><input type="text" id="memberful-lookup-wp-user-id" class="regular-text" name="lookup_wp_user_id" value="<?php echo $lookup_inputs['wp_user_id'] > 0 ? intval( $lookup_inputs['wp_user_id'] ) : ''; ?>" /></td>
+      <td><input type="text" id="memberful-lookup-wp-user-id" class="regular-text" name="wp_user_id" value="<?php echo $lookup_inputs['wp_user_id'] > 0 ? intval( $lookup_inputs['wp_user_id'] ) : ''; ?>" /></td>
     </tr>
   </table>
   <p class="submit"><button type="submit" class="button button-primary"><?php _e( 'Look up', 'memberful' ); ?></button></p>
@@ -161,8 +161,8 @@ endforeach; ?>
 </pre>
 <?php elseif ( $is_endpoint ): ?>
 <pre><code style="display:block;">
-No lookup parameters supplied. Pass one or more of: lookup_email,
-lookup_member_id, lookup_wp_user_id.
+No lookup parameters supplied. Pass one or more of: member_email,
+member_id, wp_user_id.
 </code></pre>
 <?php endif; ?>
 <?php endif; ?>


### PR DESCRIPTION
The debug tool renders all mapped and unmapped users. This is an issue on sites with many members because rendering the debug output fails.

This commit fixes it by removing the mapping info from the debug output, and adding an option to filter user/member mappings by either of email, `member_id`, or `wp_user_id`. In the UI this is a separate tab, so the debug tool is now split into system info and a member/user lookup. Over the debug endpoint the same `debug_tab` parameter selects the section, defaulting to a usage page that documents the available parameters.

Other small improvements:
- sensitive information is masked in system info and the error log
- error logs are HTML-escaped
- individual errors in the error log are separated so it's easier to scan

https://3.basecamp.com/3293071/buckets/9856127/todos/10000472282