### PR TITLE
MR-29: Copy update to gutenberg visibility settings

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/extensions/block-visibility/index.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/extensions/block-visibility/index.js
@@ -95,11 +95,11 @@ const MemberfulVisibilityControlsOptions = (props) => {
           { value: "none", label: __("All users (Default)", "memberful") },
           {
             value: "logged_in",
-            label: __("All logged-in members", "memberful"),
+            label: __("All members (active, inactive, or free)", "memberful"),
           },
           {
             value: "specific",
-            label: __("Specific membership plan", "memberful"),
+            label: __("Members with an active subscription", "memberful"),
           },
         ]}
       />
@@ -149,7 +149,7 @@ const MemberfulVisibilityControls = createHigherOrderComponent((BlockEdit) => {
         {props.isSelected && !excludedBlocks.includes(props.name) && (
           <InspectorControls>
             <PanelBody
-              title={__("Memberful Visibility", "memberful")}
+              title={__("Memberful: Restrict Access", "memberful")}
               initialOpen={false}
             >
               {MemberfulVisibilityControlsOptions(props)}


### PR DESCRIPTION
Update the wording of the visibility settings on the just-released gutenberg update to match what we have in the ad suppression visibility settings as well (which matches the metabox, etc). That way all of the language is consistent.