### PR TITLE
MR-34: Block protection styling needs a margin fix

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/extensions/block-visibility/index.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/extensions/block-visibility/index.js
@@ -1,4 +1,5 @@
 import {
+  __experimentalSpacer as Spacer,
   ToggleControl,
   SelectControl,
   CheckboxControl,
@@ -123,9 +124,11 @@ const MemberfulVisibilityControlsOptions = (props) => {
             />
           ))}
           {memberful_visibility_plans.length === 0 && (
-            <Notice status="error" isDismissible={false}>
-              {__("Please select at least one plan.", "memberful")}
-            </Notice>
+            <Spacer marginBottom={3}>
+              <Notice status="error" isDismissible={false}>
+                {__("Please select at least one plan.", "memberful")}
+              </Notice>
+            </Spacer>
           )}
         </>
       )}


### PR DESCRIPTION
# Summary
  
Adds spacing between the "Please select at least one plan." warning and the "Hide when the above conditions are met" toggle in the Memberful Visibility block inspector, so the toggle no longer sits flush against the red error notice.

# What's included
  
- Wrap the plan-selection error `Notice` in a `@wordpress/components` `Spacer`.
- Applied to the notice (which only renders when no plan is selected), so the logged-in and plans-selected states keep their existing toggle spacing.

# Test plan

- In the block editor, select a block → Memberful Visibility → "Specific membership plan" with no plans checked; confirm a clear gap between the red notice and the "Hide when the above conditions are met" toggle.
- Switch to "All logged-in members", and to "Specific membership plan" with a plan checked; confirm the toggle spacing is unchanged (no extra gap).