### PR TITLE
MR-35: Paywall divider is misaligned

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/index.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/paywall-divider/index.js
@@ -14,7 +14,7 @@ registerBlockType(metadata.name, {
         {...blockProps}
         style={{
           borderTop: "2px dashed currentColor",
-          margin: "16px 0",
+          margin: "16px auto",
           paddingTop: "8px",
           opacity: 0.6,
         }}


### PR DESCRIPTION
The paywall divider block should be aligned with the content of a post/page