### PR TITLE
MR-10: Allow setting paragraph count before paywall

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -730,6 +730,7 @@ function memberful_wp_global_marketing() {
       update_option( 'memberful_use_global_marketing', true );
       update_option( 'memberful_global_marketing_override', filter_input( INPUT_POST, 'memberful_global_marketing_override', FILTER_SANITIZE_NUMBER_INT ) );
       update_option( 'memberful_use_global_snippets', (int) isset( $_POST['memberful_use_global_snippets'] ) );
+      update_option( 'memberful_paragraph_count', min( 10, max( 1, (int) filter_input( INPUT_POST, 'memberful_paragraph_count', FILTER_SANITIZE_NUMBER_INT ) ) ) );
 
       $paywall_input = filter_input( INPUT_POST, 'memberful_paywall', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
       if ( is_array( $paywall_input ) && ! empty( $paywall_input ) ) {
@@ -749,12 +750,14 @@ function memberful_wp_global_marketing() {
   $use_global_snippets = get_option( 'memberful_use_global_snippets');
   $global_marketing_content = get_option( 'memberful_global_marketing_content' );
   $global_marketing_override = get_option( 'memberful_global_marketing_override', true );
+  $paragraph_count = get_option( 'memberful_paragraph_count', 2 );
 
   memberful_wp_render(
     'global_marketing',
     array(
       'use_global_marketing'      => $use_global_marketing,
       'use_global_snippets'       => $use_global_snippets,
+      'paragraph_count'           => $paragraph_count,
       'global_marketing_content'  => $global_marketing_content,
       'global_marketing_override' => $global_marketing_override,
       'paywall_config'            => Memberful_Paywall_Config::get(),

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -730,7 +730,7 @@ function memberful_wp_global_marketing() {
       update_option( 'memberful_use_global_marketing', true );
       update_option( 'memberful_global_marketing_override', filter_input( INPUT_POST, 'memberful_global_marketing_override', FILTER_SANITIZE_NUMBER_INT ) );
       update_option( 'memberful_use_global_snippets', (int) isset( $_POST['memberful_use_global_snippets'] ) );
-      update_option( 'memberful_paragraph_count', min( 10, max( 1, (int) filter_input( INPUT_POST, 'memberful_paragraph_count', FILTER_SANITIZE_NUMBER_INT ) ) ) );
+      update_option( 'memberful_paragraph_count', memberful_wp_clamp_paragraph_count( (int) filter_input( INPUT_POST, 'memberful_paragraph_count', FILTER_SANITIZE_NUMBER_INT ) ) );
 
       $paywall_input = filter_input( INPUT_POST, 'memberful_paywall', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
       if ( is_array( $paywall_input ) && ! empty( $paywall_input ) ) {
@@ -750,7 +750,7 @@ function memberful_wp_global_marketing() {
   $use_global_snippets = get_option( 'memberful_use_global_snippets');
   $global_marketing_content = get_option( 'memberful_global_marketing_content' );
   $global_marketing_override = get_option( 'memberful_global_marketing_override', true );
-  $paragraph_count = get_option( 'memberful_paragraph_count', 2 );
+  $paragraph_count = memberful_wp_paragraph_count();
 
   memberful_wp_render(
     'global_marketing',

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -1,6 +1,29 @@
 <?php
 
+if ( ! defined( 'MEMBERFUL_PARAGRAPH_COUNT' ) ) {
+  define( 'MEMBERFUL_PARAGRAPH_COUNT', 2 );
+}
+
 add_action( 'the_content', 'memberful_wp_protect_content', 100 );
+
+/**
+ * Clamp a paragraph count to the supported range.
+ *
+ * @param int $count Requested paragraph count.
+ * @return int
+ */
+function memberful_wp_clamp_paragraph_count( int $count ): int {
+  return min( 10, max( 1, $count ) );
+}
+
+/**
+ * Resolve the configured number of teaser paragraphs shown before the paywall.
+ *
+ * @return int
+ */
+function memberful_wp_paragraph_count(): int {
+  return memberful_wp_clamp_paragraph_count( (int) get_option( 'memberful_paragraph_count', MEMBERFUL_PARAGRAPH_COUNT ) );
+}
 
 /**
  * Get the marker inserted by the paywall divider block.

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -6,6 +6,7 @@ if ( ! defined( 'MEMBERFUL_PARAGRAPH_COUNT' ) ) {
 
 if(get_option('memberful_use_global_snippets')){
   add_filter( 'memberful_wp_protect_content', 'memberful_apply_global_snippets_content_filter', 1, 1 );
+  add_filter( 'memberful_wp_listing_excerpt', 'memberful_wp_apply_paragraph_count_to_listing_excerpt', 10, 2 );
 } else {
   add_filter( 'memberful_wp_protect_content', 'memberful_get_global_replacement', 1, 1 );
 }
@@ -75,7 +76,7 @@ function memberful_apply_global_snippets_content_filter( $memberful_marketing_co
 
   if ( !empty( $original_content ) ) {
     $teaser_offset = 0;
-    $paragraph_count = min( 10, max( 1, (int) get_option( 'memberful_paragraph_count', MEMBERFUL_PARAGRAPH_COUNT ) ) );
+    $paragraph_count = memberful_wp_paragraph_count();
 
     for ( $i = 0; $i < $paragraph_count; $i++ ) {
       $paragraph_offset = strpos( $original_content, '</p>', $teaser_offset );
@@ -119,4 +120,32 @@ function memberful_get_teaser_css(){
 CSS;
 
   return $css;
+}
+
+/**
+ * Resolve the configured number of teaser paragraphs shown before the paywall.
+ *
+ * @return int
+ */
+function memberful_wp_paragraph_count(): int {
+  return min( 10, max( 1, (int) get_option( 'memberful_paragraph_count', MEMBERFUL_PARAGRAPH_COUNT ) ) );
+}
+
+/**
+ * Recut the archive listing excerpt to the configured paragraph count.
+ *
+ * @param string $teaser  Teaser produced for the listing.
+ * @param string $content Full rendered post content.
+ * @return string
+ */
+function memberful_wp_apply_paragraph_count_to_listing_excerpt( $teaser, $content ) {
+  if ( ! function_exists( 'memberful_wp_first_paragraphs' ) ) {
+    return $teaser;
+  }
+
+  if ( false !== strpos( (string) $content, memberful_wp_get_paywall_divider_marker() ) ) {
+    return $teaser;
+  }
+
+  return memberful_wp_first_paragraphs( (string) $content, memberful_wp_paragraph_count() );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -1,9 +1,5 @@
 <?php
 
-if ( ! defined( 'MEMBERFUL_PARAGRAPH_COUNT' ) ) {
-  define( 'MEMBERFUL_PARAGRAPH_COUNT', 2 );
-}
-
 if(get_option('memberful_use_global_snippets')){
   add_filter( 'memberful_wp_protect_content', 'memberful_apply_global_snippets_content_filter', 1, 1 );
   add_filter( 'memberful_wp_listing_excerpt', 'memberful_wp_apply_paragraph_count_to_listing_excerpt', 10, 2 );
@@ -120,15 +116,6 @@ function memberful_get_teaser_css(){
 CSS;
 
   return $css;
-}
-
-/**
- * Resolve the configured number of teaser paragraphs shown before the paywall.
- *
- * @return int
- */
-function memberful_wp_paragraph_count(): int {
-  return min( 10, max( 1, (int) get_option( 'memberful_paragraph_count', MEMBERFUL_PARAGRAPH_COUNT ) ) );
 }
 
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/global_marketing.php
@@ -75,8 +75,9 @@ function memberful_apply_global_snippets_content_filter( $memberful_marketing_co
 
   if ( !empty( $original_content ) ) {
     $teaser_offset = 0;
+    $paragraph_count = min( 10, max( 1, (int) get_option( 'memberful_paragraph_count', MEMBERFUL_PARAGRAPH_COUNT ) ) );
 
-    for ( $i = 0; $i < MEMBERFUL_PARAGRAPH_COUNT; $i++ ) {
+    for ( $i = 0; $i < $paragraph_count; $i++ ) {
       $paragraph_offset = strpos( $original_content, '</p>', $teaser_offset );
 
       if ( $paragraph_offset === false ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/options.php
@@ -30,6 +30,7 @@ function memberful_wp_all_options(): array {
     'memberful_use_global_snippets'                    => TRUE,
     'memberful_global_marketing_override'              => TRUE,
     'memberful_global_marketing_content'               => '',
+    'memberful_paragraph_count'                        => 2,
     'memberful_ad_provider_settings'                   => array(),
     Memberful_Paywall_Config::OPTION_KEY               => array(),
   );

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/admin.css
@@ -167,6 +167,19 @@ Global Marketing Tools
   padding-left: 2em;
 }
 
+/* "Paragraphs before paywall" field — match the paywall builder field styling */
+#global_marketing_paragraph_count_option .memberful-paywall-builder__field {
+  margin: 1.5em 0 0 1.8em;
+}
+#global_marketing_paragraph_count_option .memberful-paywall-builder__field label {
+  color: #6b7280;
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+}
+
 /*---------------------------------------------------------
 Restrict Access Metabox
 ------------------------------------------------------------ */

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -6,6 +6,7 @@
  *
  * @var bool   $use_global_marketing
  * @var bool   $use_global_snippets
+ * @var int    $paragraph_count
  * @var bool   $global_marketing_override
  * @var string $global_marketing_content
  * @var array  $paywall_config
@@ -48,9 +49,16 @@
 						<input id="use_global_snippets_checkbox" class="memberful-label__checkbox--multiline" type="checkbox" name="memberful_use_global_snippets" <?php checked( $use_global_snippets ); ?>>
 						<small class="memberful-label__text--multiline">
 							<strong><?php esc_html_e( 'Automatically pull an excerpt from each post.', 'memberful' ); ?></strong>
-							<?php esc_html_e( ' Memberful will pull the first two paragraphs from each protected post to use as marketing content for logged out visitors. This feature requires <p> tags in your posts to detect which content to use. If a post contains a Memberful Paywall Divider block, all content above the divider will be shown instead of the excerpt.', 'memberful' ); ?>
+							<?php esc_html_e( ' Memberful will pull the opening paragraphs from each protected post to use as marketing content for logged out visitors. This feature requires <p> tags in your posts to detect which content to use. If a post contains a Memberful Paywall Divider block, all content above the divider will be shown instead of the excerpt.', 'memberful' ); ?>
 						</small>
 					</label>
+
+					<div id="global_marketing_paragraph_count_option" data-depends-on="use_global_snippets_checkbox" data-depends-value="1"<?php if ( ! $use_global_snippets ) echo ' style="display:none"'; ?>>
+						<p class="memberful-paywall-builder__field">
+							<label for="memberful_paragraph_count"><?php esc_html_e( 'Paragraphs before paywall', 'memberful' ); ?></label>
+							<input id="memberful_paragraph_count" type="number" min="1" max="10" name="memberful_paragraph_count" value="<?php echo esc_attr( max( 1, (int) $paragraph_count ) ); ?>">
+						</p>
+					</div>
 				</div>
 			</div>
 

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -56,7 +56,7 @@
 					<div id="global_marketing_paragraph_count_option" data-depends-on="use_global_snippets_checkbox" data-depends-value="1"<?php if ( ! $use_global_snippets ) echo ' style="display:none"'; ?>>
 						<p class="memberful-paywall-builder__field">
 							<label for="memberful_paragraph_count"><?php esc_html_e( 'Paragraphs before paywall', 'memberful' ); ?></label>
-							<input id="memberful_paragraph_count" type="number" min="1" max="10" name="memberful_paragraph_count" value="<?php echo esc_attr( min( 10, max( 1, $paragraph_count ) ) ); ?>">
+							<input id="memberful_paragraph_count" type="number" min="1" max="10" name="memberful_paragraph_count" value="<?php echo esc_attr( $paragraph_count ); ?>">
 						</p>
 					</div>
 				</div>

--- a/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/global_marketing.php
@@ -56,7 +56,7 @@
 					<div id="global_marketing_paragraph_count_option" data-depends-on="use_global_snippets_checkbox" data-depends-value="1"<?php if ( ! $use_global_snippets ) echo ' style="display:none"'; ?>>
 						<p class="memberful-paywall-builder__field">
 							<label for="memberful_paragraph_count"><?php esc_html_e( 'Paragraphs before paywall', 'memberful' ); ?></label>
-							<input id="memberful_paragraph_count" type="number" min="1" max="10" name="memberful_paragraph_count" value="<?php echo esc_attr( max( 1, (int) $paragraph_count ) ); ?>">
+							<input id="memberful_paragraph_count" type="number" min="1" max="10" name="memberful_paragraph_count" value="<?php echo esc_attr( min( 10, max( 1, $paragraph_count ) ) ); ?>">
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
# Summary

Customise how many paragraphs before paywall with global marketing content.

# What's included

- New memberful_paragraph_count option (1–10, default 2), registered in memberful_wp_all_options().
- New "Paragraphs before paywall" number field on the Global marketing content screen, shown only when "Automatically pull an excerpt" is enabled.
- The auto-excerpt teaser now reads the option (clamped 1–10) instead of the hardcoded MEMBERFUL_PARAGRAPH_COUNT constant, which is kept as the fallback default.

# Test plan

- On Settings → Memberful → Global marketing content, enable "Automatically pull an excerpt", set "Paragraphs before paywall" to N, save, and confirm the value persists (and that the field shows/hides with the excerpt checkbox).
- View a protected post with ≥N <p> paragraphs and no Paywall Divider block as a logged-out visitor, and confirm exactly N paragraphs appear before the paywall; posts using a Paywall Divider block are unaffected.
- Confirm out-of-range values clamp on save (0 → 1, 50 → 10).