### PR TITLE
Fix comments feed protection issues

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -116,6 +116,9 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 * Add a visual paywall builder for creating branded paywalls without writing HTML
 * Allow customizing how many paragraphs appear before the paywall
+* Fix the comments feed on sites with no protected posts
+* Fix PHP warning when checking comment access on feed requests for missing posts
+* Hide comments on term-protected posts from comment feeds
 
 = 1.81.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -119,6 +119,7 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 * Fix the comments feed on sites with no protected posts
 * Fix PHP warning when checking comment access on feed requests for missing posts
 * Hide comments on term-protected posts from comment feeds
+* Apply term protections to pages and custom post types in search and comment feeds
 
 = 1.81.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -415,7 +415,7 @@ function _memberful_wp_posts_with_terms( $terms ) {
     $tax_query = array_merge( array( 'relation' => 'OR' ), $tax_query );
   }
 
-  return get_posts( array( 'tax_query' => $tax_query, 'fields' => 'ids', 'numberposts' => -1 ) );
+  return get_posts( array( 'post_type' => 'any', 'tax_query' => $tax_query, 'fields' => 'ids', 'numberposts' => -1 ) );
 }
 
 function _memberful_wp_group_terms_by_taxonomy( $term_ids ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/comments_protection.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/comments_protection.php
@@ -33,6 +33,10 @@ function memberful_user_can_access_comments(){
 
   global $post;
 
+  if ( ! $post instanceof WP_Post ) {
+    return true;
+  }
+
   // User has access to this post, we won't do anything.
   if ( memberful_can_user_access_post( wp_get_current_user()->ID, $post->ID ) )
     return true;
@@ -71,9 +75,8 @@ function memberful_post_is_protected($post_id=null){
   if(!isset($post_id))
     $post_id=get_the_ID();
 
-  $acl= get_option( 'memberful_acl', array());
-  $restricted=memberful_get_protected_post_IDS();
-  return in_array($post_id, $restricted);
+  $restricted = memberful_wp_user_disallowed_post_ids( 0 );
+  return in_array( $post_id, $restricted );
 }
 
 /**
@@ -84,24 +87,6 @@ function memberful_remove_feed(){
   remove_action( 'do_feed_rss2', 'do_feed_rss2', 10, 1 );
   remove_action( 'do_feed_atom', 'do_feed_atom', 10, 1 );
 }
-
-/**
-* Return an array of all post IDs that are protected by the memberful plugin
-*/
-function memberful_get_protected_post_IDS(){
-  $acl= get_option( 'memberful_acl', array());
-  $registered=get_option('memberful_posts_available_to_any_registered_user', array());
-  $private=array();
-  foreach($acl as $restricted){
-    if(!is_array($restricted))
-      continue;
-    foreach($restricted as $protected_posts){
-      $private=array_merge($private, $protected_posts);
-    }
-  }
-  return array_unique(array_merge($private, $registered));
-}
-
 
 add_filter('comment_feed_where', 'memberful_comment_feed_cwhere_filter', 10, 2);
 
@@ -114,9 +99,16 @@ function memberful_comment_feed_cwhere_filter($cwhere, $query){
   if(!$query->is_feed() || is_singular())
     return $cwhere;
 
+  $restricted = memberful_wp_user_disallowed_post_ids( 0 );
+
+  if ( empty( $restricted ) ) {
+    return $cwhere;
+  }
+
   global $wpdb;
-  $restricted=implode(',', memberful_get_protected_post_IDS());
-  $cwhere.= "AND {$wpdb->posts}.ID NOT IN ($restricted)";
+  $placeholders = implode( ',', array_fill( 0, count( $restricted ), '%d' ) );
+  $cwhere      .= $wpdb->prepare( " AND {$wpdb->posts}.ID NOT IN ($placeholders)", $restricted );
+
   return $cwhere;
 }
 ?>


### PR DESCRIPTION
* 24e8baaf **Fix comments feed protection issues**
  
  The comments feed was broken on sites with no protected posts because
  the feed query filter generated invalid SQL (`NOT IN ()`). The exclusion
  list also missed posts protected by term rules, so their comments
  leaked into the feed. Both feed paths now use
  `memberful_wp_user_disallowed_post_ids( 0 )`, which covers the full
  protection model for anonymous visitors (feeds are fetched by readers
  and crawlers without auth).
  
  Also guard against a null `$post` in `memberful_user_can_access_comments()`,
  which logged a PHP warning on feed requests for missing posts.
  
  Fixes: https://app.basecamp.com/3293071/buckets/5610905/card_tables/cards/10255383946

* d20dfba4 **Apply term protections to all post types**

