### PR TITLE
Fix comments feed protection issues

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/readme.txt
+++ b/wordpress/wp-content/plugins/memberful-wp/readme.txt
@@ -116,6 +116,10 @@ Glad you asked! We manage development of the plugin over at the [Memberful WP Gi
 
 * Add a visual paywall builder for creating branded paywalls without writing HTML
 * Allow customizing how many paragraphs appear before the paywall
+* Fix the comments feed on sites with no protected posts
+* Fix PHP warning when checking comment access on feed requests for missing posts
+* Hide comments on term-protected posts from comment feeds
+* Apply term protections to pages and custom post types in search and comment feeds
 
 = 1.81.0 =
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -10,6 +10,12 @@ require_once MEMBERFUL_DIR . '/src/acl/term_options.php';
  * @return array An array of post IDs that the user is not allowed to access.
  */
 function memberful_wp_user_disallowed_post_ids( $user_id ) {
+  static $cache = array();
+
+  if ( isset( $cache[$user_id] ) ) {
+    return $cache[$user_id];
+  }
+
   $user_posts = _memberful_wp_items_from_acl(
     get_option( 'memberful_acl', array() ),
     $user_id,
@@ -33,7 +39,9 @@ function memberful_wp_user_disallowed_post_ids( $user_id ) {
   // Remove posts allowed by Post ACL or Term ACL
   $disallowed_posts = array_diff( $disallowed_posts, $user_posts['allowed'], $posts_allowed_by_terms );
 
-  return $disallowed_posts;
+  $cache[$user_id] = $disallowed_posts;
+
+  return $cache[$user_id];
 }
 
 /**
@@ -415,7 +423,9 @@ function _memberful_wp_posts_with_terms( $terms ) {
     $tax_query = array_merge( array( 'relation' => 'OR' ), $tax_query );
   }
 
-  return get_posts( array( 'tax_query' => $tax_query, 'fields' => 'ids', 'numberposts' => -1 ) );
+  $post_types = array_values( memberful_wp_metabox_types() );
+
+  return get_posts( array( 'post_type' => $post_types, 'orderby' => 'none', 'tax_query' => $tax_query, 'fields' => 'ids', 'numberposts' => -1 ) );
 }
 
 function _memberful_wp_group_terms_by_taxonomy( $term_ids ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/comments_protection.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/comments_protection.php
@@ -33,11 +33,13 @@ function memberful_user_can_access_comments(){
 
   global $post;
 
-  // User has access to this post, we won't do anything.
-  if ( memberful_can_user_access_post( wp_get_current_user()->ID, $post->ID ) )
+  $post_id = isset( $post->ID ) ? (int) $post->ID : get_queried_object_id();
+
+  if ( ! $post_id )
     return true;
 
-  return false;
+  // User has access to this post, we won't do anything.
+  return memberful_can_user_access_post( wp_get_current_user()->ID, $post_id );
 }
 
 
@@ -49,13 +51,7 @@ add_action( 'do_feed_atom', 'memberful_single_feed_comments_protection', 9, 1 );
 *@return null
 */
 function memberful_single_feed_comments_protection($for_comments){
-    if(!$for_comments)
-      return;
-      
-    if(!is_singular())
-      return;
-
-    if(is_singular() && !memberful_post_is_protected())
+    if ( ! $for_comments || ! is_singular() || ! memberful_post_is_protected() )
       return;
 
     memberful_remove_feed();
@@ -71,9 +67,10 @@ function memberful_post_is_protected($post_id=null){
   if(!isset($post_id))
     $post_id=get_the_ID();
 
-  $acl= get_option( 'memberful_acl', array());
-  $restricted=memberful_get_protected_post_IDS();
-  return in_array($post_id, $restricted);
+  if ( empty( $post_id ) )
+    return false;
+
+  return ! memberful_can_user_access_post( 0, $post_id );
 }
 
 /**
@@ -85,24 +82,6 @@ function memberful_remove_feed(){
   remove_action( 'do_feed_atom', 'do_feed_atom', 10, 1 );
 }
 
-/**
-* Return an array of all post IDs that are protected by the memberful plugin
-*/
-function memberful_get_protected_post_IDS(){
-  $acl= get_option( 'memberful_acl', array());
-  $registered=get_option('memberful_posts_available_to_any_registered_user', array());
-  $private=array();
-  foreach($acl as $restricted){
-    if(!is_array($restricted))
-      continue;
-    foreach($restricted as $protected_posts){
-      $private=array_merge($private, $protected_posts);
-    }
-  }
-  return array_unique(array_merge($private, $registered));
-}
-
-
 add_filter('comment_feed_where', 'memberful_comment_feed_cwhere_filter', 10, 2);
 
 /**
@@ -111,12 +90,18 @@ add_filter('comment_feed_where', 'memberful_comment_feed_cwhere_filter', 10, 2);
 */
 
 function memberful_comment_feed_cwhere_filter($cwhere, $query){
-  if(!$query->is_feed() || is_singular())
+  if ( ! $query->is_feed() || $query->is_singular() )
+    return $cwhere;
+
+  $restricted = memberful_wp_user_disallowed_post_ids( 0 );
+
+  if ( empty( $restricted ) )
     return $cwhere;
 
   global $wpdb;
-  $restricted=implode(',', memberful_get_protected_post_IDS());
-  $cwhere.= "AND {$wpdb->posts}.ID NOT IN ($restricted)";
+  $ids     = implode( ',', array_map( 'absint', $restricted ) );
+  $cwhere .= " AND {$wpdb->posts}.ID NOT IN ($ids)";
+
   return $cwhere;
 }
 ?>


### PR DESCRIPTION
* 21397125 **Fix comments feed protection issues**
  
  - Fix broken SQL in the site-wide comments feed when no posts are protected
  - Fix PHP warning when checking comment access on feed requests for missing posts
  - Hide comments on term-protected posts from the site-wide comments feed
  - Check the singularity of the query being filtered instead of the main query
  - Reuse `memberful_can_user_access_post()` for the singular feed check instead
    of materializing the full list of protected post IDs
  
  Fixes: https://app.basecamp.com/3293071/buckets/5610905/card_tables/cards/10255383946

* a499ce1f **Apply term protections to all supported post types**

